### PR TITLE
Add status history to barrier updates

### DIFF
--- a/src/app/app.spec.js
+++ b/src/app/app.spec.js
@@ -267,6 +267,10 @@ describe( 'App', function(){
 							.get( `/barriers/${ barrier.id }/interactions` )
 							.reply( 200, intercept.stub( '/backend/barriers/interactions' ) );
 
+						intercept.backend()
+							.get( `/barriers/${ barrier.id }/status_history` )
+							.reply( 200, intercept.stub( '/backend/barriers/status_history' ) );
+
 						app
 							.get( urls.barriers.interactions( barrierId ) )
 							.end( checkPage( 'Market Access - Barrier updates', done ) );

--- a/src/app/lib/backend-service.js
+++ b/src/app/lib/backend-service.js
@@ -157,6 +157,7 @@ module.exports = {
 		},
 		get: ( req, barrierId ) => backend.get( `/barriers/${ barrierId }`, getToken( req ) ),
 		getInteractions: ( req, barrierId ) => backend.get( `/barriers/${ barrierId }/interactions`, getToken( req ) ),
+		getStatusHistory: ( req, barrierId ) => backend.get( `/barriers/${ barrierId }/status_history`, getToken( req ) ),
 		notes: {
 			save: ( req, barrierId, values ) => backend.post( `/barriers/${ barrierId }/interactions`, getToken( req ), {
 				text: values.note,

--- a/src/app/lib/backend-service.spec.js
+++ b/src/app/lib/backend-service.spec.js
@@ -155,6 +155,15 @@ describe( 'Backend Service', () => {
 			} );
 		} );
 
+		describe( 'getStatusHistory', () => {
+			it( 'Should call the correct path', async () => {
+
+				await service.barriers.getStatusHistory( req, barrierId );
+
+				expect( backend.get ).toHaveBeenCalledWith( `/barriers/${ barrierId }/status_history`, token );
+			} );
+		} );
+
 		describe( 'notes', () => {
 			describe( 'save', () => {
 				it( 'Should POST to the correct path with the correct values', async () => {

--- a/src/app/lib/nunjucks-filters/index.js
+++ b/src/app/lib/nunjucks-filters/index.js
@@ -7,4 +7,5 @@ module.exports = function( env ){
 	env.addFilter( 'errorForName', require( './error-for-name' ) );
 	env.addFilter( 'metadataName', require( './metadata-name' ) );
 	env.addFilter( 'addToRadio', require( './add-to-radio' ) );
+	env.addFilter( 'time', require( './time' ) );
 };

--- a/src/app/lib/nunjucks-filters/index.spec.js
+++ b/src/app/lib/nunjucks-filters/index.spec.js
@@ -15,6 +15,7 @@ describe( 'Nunjucks filters', function(){
 		[ './error-for-name', 'errorForName' ],
 		[ './metadata-name', 'metadataName' ],
 		[ './add-to-radio', 'addToRadio' ],
+		[ './time', 'time' ],
 	];
 
 	beforeEach( function(){

--- a/src/app/lib/nunjucks-filters/time.js
+++ b/src/app/lib/nunjucks-filters/time.js
@@ -1,0 +1,19 @@
+const dateFormat = require( 'dateformat' );
+
+function isValid( datestr ){
+
+	return ( typeof datestr === 'number' ) || !!Date.parse( datestr );
+}
+
+module.exports = function( datestr ){
+
+	let date;
+
+	if( datestr && isValid( datestr ) ){
+
+		date = new Date( datestr );
+		return dateFormat( date, 'GMT:h:MMtt' );
+	}
+
+	return datestr;
+};

--- a/src/app/lib/nunjucks-filters/time.spec.js
+++ b/src/app/lib/nunjucks-filters/time.spec.js
@@ -1,0 +1,38 @@
+const time = require( './time' );
+
+describe( 'Time filter', function(){
+	describe( 'When a date is supplied', function(){
+		describe( 'With a UTC timestamp', function(){
+			it( 'Should return the correct date and time', function(){
+
+				expect( time( 1491004799 * 1000 ) ).toEqual( '11:59pm' );
+			} );
+		} );
+
+		describe( 'With a GMT date string', function(){
+			it( 'Should return the correct date and time', function(){
+
+				expect( time( 'Fri, 31 Mar 2017 00:00:00 GMT' ) ).toEqual( '12:00am' );
+			} );
+		} );
+
+		describe( 'With a random string', function(){
+			it( 'Should return the input', function(){
+
+				expect( time( 'random string' ) ).toEqual( 'random string' );
+			} );
+		} );
+
+		it( 'Should return the date and the time', function(){
+
+			expect( time( 1487928284460 ) ).toEqual( '9:24am' );
+		} );
+	} );
+
+	describe( 'When the date is not supplied', function(){
+		it( 'Should return the input', function(){
+
+			expect( time() ).toEqual();
+		} );
+	} );
+} );

--- a/src/app/sub-apps/barriers/view-models/interactions.js
+++ b/src/app/sub-apps/barriers/view-models/interactions.js
@@ -1,0 +1,76 @@
+const metadata = require( '../../../lib/metadata' );
+
+function getStatusType( id ){
+
+	const typeInfo = metadata.barrier.status.typeInfo;
+
+	if( id !== null && typeInfo.hasOwnProperty( id ) ){
+
+		return typeInfo[ id ].name;
+	}
+
+	return  id;
+}
+
+function sortByDateDescending( a, b ){
+
+	const aDate = Date.parse( a.date );
+	const bDate = Date.parse( b.date );
+
+	return ( aDate === bDate ? 0 : ( aDate > bDate ? -1 : 1 ) );
+}
+
+function getNotes( items, editId ){
+
+	const notes = [];
+
+	for( let item of items ){
+
+		notes.push( {
+			id: item.id,
+			isNote: true,
+			edit: ( item.id == editId ),
+			date: item.created_on,
+			text: item.text,
+			user: item.created_by
+		} );
+	}
+
+	return notes;
+}
+
+function getStatuses( items ){
+
+	const statuses = [];
+
+	for( let item of items ){
+
+		statuses.push( {
+			isStatus: true,
+			date: item.date,
+			event: item.event,
+			state: {
+				from: getStatusType( item.old_status ),
+				to: getStatusType( item.new_status ),
+				date: item.status_date,
+				isResolved: ( item.new_status === metadata.barrier.status.types.RESOLVED )
+			},
+			text: item.status_summary,
+			user: item.user,
+		} );
+	}
+
+	return statuses;
+}
+
+module.exports = function ( responses, editId ){
+
+	const notes = getNotes( responses.interactions.results, editId );
+	const statuses = getStatuses( responses.statusHistory.status_history );
+
+	//pinned.sort( sortByDateDescending );
+	//other.sort( sortByDateDescending );
+	//return pinned.concat( other );
+
+	return notes.concat( statuses ).sort( sortByDateDescending );
+};

--- a/src/app/sub-apps/barriers/view-models/interactions.spec.js
+++ b/src/app/sub-apps/barriers/view-models/interactions.spec.js
@@ -1,0 +1,68 @@
+const modulePath = './interactions';
+
+const getFakeData = jasmine.helpers.getFakeData;
+
+const OPEN = 'Open';
+const RESOLVED = 'Resolved';
+const PAUSED = 'Paused';
+
+describe( 'Interactions view model', () => {
+
+	let viewModel;
+
+	beforeEach( () => {
+
+		viewModel = require( modulePath );
+	} );
+
+	function createNote( item, edit = false ){
+		return {
+			id: item.id,
+			isNote: true,
+			edit,
+			date: item.created_on,
+			text: item.text,
+			user: item.created_by,
+		};
+	}
+
+	function createStatus( item, from, to, isResolved ){
+		return {
+			isStatus: true,
+			date: item.date,
+			event: item.event,
+			state: {
+				from,
+				to,
+				date: item.status_date,
+				isResolved
+			},
+			text: item.status_summary,
+			user: item.user,
+		};
+	}
+
+	it( 'Should combine the results and sort them', () => {
+
+		const interactionsResults = getFakeData( '/backend/barriers/interactions-ordered' ).results;
+		const statusHistoryResults = getFakeData( '/backend/barriers/status_history' ).status_history;
+
+		const output = viewModel( {
+			interactions: getFakeData( '/backend/barriers/interactions-ordered' ),
+			statusHistory: getFakeData( '/backend/barriers/status_history' )
+		}, String( interactionsResults[ 3 ].id ) );
+
+		expect( output ).toEqual( [
+			createNote( interactionsResults[ 3 ], true ),
+			createNote( interactionsResults[ 4 ] ),
+			createNote( interactionsResults[ 2 ] ),
+			createStatus( statusHistoryResults[ 2 ], RESOLVED, OPEN, false ),
+			createNote( interactionsResults[ 0 ] ),
+			createStatus( statusHistoryResults[ 4 ], OPEN, PAUSED, false ),
+			createStatus( statusHistoryResults[ 3 ], OPEN, RESOLVED, true ),
+			createNote( interactionsResults[ 1 ] ),
+			createStatus( statusHistoryResults[ 1 ], 0, OPEN, false ),
+			createStatus( statusHistoryResults[ 0 ], null, 0, false ),
+		] );
+	} );
+} );

--- a/src/app/sub-apps/barriers/views/interactions.njk
+++ b/src/app/sub-apps/barriers/views/interactions.njk
@@ -57,31 +57,67 @@
 			{% for item in interactions %}
 			<li class="event-list__item{#{ ' event-list__item--pinned' if item.pinned }#}">
 
-				<h4 class="event-list__item__heading">{{ item.created_on | dateWithTime }}</h4>
+				<h4 class="event-list__item__heading">{{ item.date | dateOnly }}<span class="event-list__item__heading__time"> at {{ item.date | time }} (GMT)</span></h4>
 
-				{% if item.edit %}
-					<form action="{{ urls.barriers.notes.edit( barrier.id, item.id ) }}" method="POST">
-						<input type="hidden" name="_csrf" value="{{ csrfToken }}">
-						{{ govukTextarea({
-							name: 'note',
-							id: 'note',
-							label: {
-								text: 'Add notes on an interaction or event',
-								classes: 'visually-hidden'
-							},
-							value: item.text,
-							attributes: {
-								autofocus: ''
-							},
-							errorMessage: errors | errorForName( 'note' )
-						}) }}
-						<input type="submit" value="Save note" class="govuk-button">
-						<a href="{{ urls.barriers.interactions( barrier.id ) }}" class="form-cancel">Cancel</a>
-					</form>
-				{% else %}
-					<p class="event-list__item__text">{{ item.text | escape | nl2br  }}</p>
-					<a href="{{ urls.barriers.notes.edit( barrier.id, item.id ) }}">edit</a>
-				{% endif %}
+				{%- if item.isNote -%}
+
+					{% if item.edit -%}
+
+						<form action="{{ urls.barriers.notes.edit( barrier.id, item.id ) }}" method="POST">
+							<input type="hidden" name="_csrf" value="{{ csrfToken }}">
+							{{ govukTextarea({
+								name: 'note',
+								id: 'note',
+								label: {
+									text: 'Add notes on an interaction or event',
+									classes: 'visually-hidden'
+								},
+								value: item.text,
+								attributes: {
+									autofocus: ''
+								},
+								errorMessage: errors | errorForName( 'note' )
+							}) }}
+							<input type="submit" value="Save note" class="govuk-button">
+							<a href="{{ urls.barriers.interactions( barrier.id ) }}" class="form-cancel">Cancel</a>
+						</form>
+
+					{%- else -%}
+
+						<p class="event-list__item__text">{{ item.text | escape | nl2br  }}</p>
+						<a href="{{ urls.barriers.notes.edit( barrier.id, item.id ) }}">edit</a>
+
+					{%- endif %}
+
+				{%- elif item.isStatus -%}
+
+					<p class="event-list__item__text">
+
+					{%- if item.event === 'REPORT_CREATED' -%}
+
+						Report of barrier started by <strong>{{ item.user.name }}</strong>
+
+					{%- elif item.event === 'BARRIER_CREATED' -%}
+
+						Barrier created by <strong>{{ item.user.name }}</strong>
+
+					{%- elif item.event === 'BARRIER_STATUS_CHANGE' -%}
+
+						Barrier status changed from <strong>{{ item.state.from }}</strong> to <strong>{{ item.state.to }}</strong>{{ ' by ' + item.user.name if item.user.name }}.
+
+						{%- if item.state.isResolved %}
+
+							 Resolved date set as <strong>{{ item.state.date | dateOnly( day = false ) }}</strong>.
+
+						{%- endif %}
+					{%- endif %}
+					</p>
+
+					{% if item.event === 'BARRIER_STATUS_CHANGE' -%}
+						<p class="event-list__item__text">{{ item.text | escape | nl2br  }}</p>
+					{% endif -%}
+
+				{%- endif %}
 			</li>
 			{% endfor %}
 		</ol>

--- a/src/app/sub-apps/barriers/views/interactions.njk
+++ b/src/app/sub-apps/barriers/views/interactions.njk
@@ -57,9 +57,13 @@
 			{% for item in interactions %}
 			<li class="event-list__item{#{ ' event-list__item--pinned' if item.pinned }#}">
 
-				<h4 class="event-list__item__heading">{{ item.date | dateOnly }}<span class="event-list__item__heading__time"> at {{ item.date | time }} (GMT)</span></h4>
-
 				{%- if item.isNote -%}
+
+					<h4 class="event-list__item__heading">{{ item.date | dateOnly }}<span class="event-list__item__heading__recede"> at {{ item.date | time }} (GMT)</span>
+						{%- if item.user.name -%}
+						<span class="event-list__item__heading__recede"> by </span>{{ item.user.name }}
+						{%- endif -%}
+					</h4>
 
 					{% if item.edit -%}
 
@@ -91,15 +95,17 @@
 
 				{%- elif item.isStatus -%}
 
+					<h4 class="event-list__item__heading">{{ item.date | dateOnly }}<span class="event-list__item__heading__recede"> at {{ item.date | time }} (GMT)</span></h4>
+
 					<p class="event-list__item__text">
 
 					{%- if item.event === 'REPORT_CREATED' -%}
 
-						Report of barrier started by <strong>{{ item.user.name }}</strong>
+						Report of barrier started{% if item.user.name %} by <strong>{{ item.user.name }}</strong>{% endif %}
 
 					{%- elif item.event === 'BARRIER_CREATED' -%}
 
-						Barrier created by <strong>{{ item.user.name }}</strong>
+						Barrier created{% if item.user.name %} by <strong>{{ item.user.name }}</strong>{% endif %}
 
 					{%- elif item.event === 'BARRIER_STATUS_CHANGE' -%}
 

--- a/src/data/faker/backend.js
+++ b/src/data/faker/backend.js
@@ -11,7 +11,8 @@ const jsonFiles = {
 	'reports/report': generateSchema( '/backend/reports/report' ),
 	'barriers/index': generateSchema( '/backend/barriers/index' ),
 	'barriers/barrier': generateSchema( '/backend/barriers/barrier' ),
-	'barriers/interactions': generateSchema( '/backend/barriers/interactions' )
+	'barriers/interactions': generateSchema( '/backend/barriers/interactions' ),
+	'barriers/status_history': generateSchema( '/backend/barriers/status-history' ),
 };
 
 writeJsonFiles( OUTPUT_PATH, jsonFiles );

--- a/src/data/schema/$refs/common.json
+++ b/src/data/schema/$refs/common.json
@@ -9,6 +9,11 @@
 		"pattern": "B-[0-9]{2}-[A-Z0-9]{3}"
 	},
 
+	"barrier-event": {
+		"type": "string",
+		"pattern": "REPORT_CREATED|BARRIER_CREATED|BARRIER_STATUS_CHANGE"
+	},
+
 	"word": {
 		"type": "string",
 		"faker": "lorem.word"

--- a/src/data/schema/backend/barriers/status-history.json
+++ b/src/data/schema/backend/barriers/status-history.json
@@ -1,0 +1,50 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "List of barrier status history",
+
+	"type": "object",
+	"required": [ "status_history" ],
+	"properties": {
+
+		"status_history": {
+			"type": "array",
+			"minItems": 2,
+			"maxItems": 10,
+			"items": {
+				"$ref": "#/refs/item"
+			}
+		}
+	},
+
+	"refs": {
+		"item": {
+			"type": "object",
+			"required": [
+				"date",
+				"status_date",
+				"event",
+				"old_status",
+				"new_status",
+				"status_summary",
+				"user"
+			],
+			"properties": {
+
+				"date": { "$ref": "$refs/common.json#/past-date" },
+				"status_date": { "$ref": "$refs/common.json#/past-date" },
+				"event": { "$ref": "$refs/common.json#/barrier-event" },
+				"old_status": { "$ref": "$refs/common.json#/small-int" },
+				"new_status": { "$ref": "$refs/common.json#/small-int" },
+				"status_summary": { "$ref": "$refs/common.json#/words" },
+				"user": {
+					"type": "object",
+					"required": [ "id", "name" ],
+					"properties": {
+						"id": { "$ref": "$refs/common.json#/small-int" },
+						"name": { "$ref": "$refs/common.json#/word" }
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/public/sass/app-components/_event-list.scss
+++ b/src/public/sass/app-components/_event-list.scss
@@ -11,16 +11,32 @@
 	position: relative;
 	margin-left: govuk-em( 30, 16 );
 
-	&::before {
+	&:before {
 		content: '';
 		position: absolute;
 		top: govuk-em( 17, 16 );
 		left: govuk-em( -35, 16 );
 		display: inline-block;
-		border: 5px solid $govuk-grey-2;
+		border: 5px solid $govuk-grey-3;
 		border-radius: 50%;
 		width: 10px;
 		height: 10px;
+		z-index: 10;
+		background: white;
+	}
+
+	&:after {
+		content: '';
+		border-left: 3px solid $govuk-grey-3;
+		height: 120%;
+		display: inline-block;
+		position: absolute;
+		top: govuk-em( 17, 16 );
+		left: govuk-em( -27, 16 );
+	}
+
+	&:last-of-type:after {
+		border-color: white;
 	}
 }
 

--- a/src/public/sass/app-components/_event-list.scss
+++ b/src/public/sass/app-components/_event-list.scss
@@ -59,7 +59,7 @@
 	color: $govuk-grey-1;
 }
 
-.event-list__item__heading__time {
+.event-list__item__heading__recede {
 	font-weight: normal;
 }
 

--- a/src/public/sass/app-components/_event-list.scss
+++ b/src/public/sass/app-components/_event-list.scss
@@ -14,16 +14,17 @@
 	&::before {
 		content: '';
 		position: absolute;
-		top: govuk-em( 16, 16 );
+		top: govuk-em( 17, 16 );
 		left: govuk-em( -35, 16 );
 		display: inline-block;
-		border: 5px solid $govuk-fuchsia;
+		border: 5px solid $govuk-grey-2;
 		border-radius: 50%;
-		width: 12px;
-		height: 12px;
+		width: 10px;
+		height: 10px;
 	}
 }
 
+/*
 .event-list__item--pinned {
 
 	border: 0;
@@ -34,13 +35,24 @@
 		left: govuk-em( -43, 16 );
 	}
 }
+*/
 
 .event-list__item__heading {
 	margin-top: 0;
 	margin-bottom: govuk-em( 15, 16 );
+	color: $govuk-grey-1;
+}
+
+.event-list__item__heading__time {
+	font-weight: normal;
 }
 
 .event-list__item__text {
+
 	@include govuk-font( $size: 19 );
-	margin: 0;
+	margin: 0 0 govuk-em( 15, 19 ) 0;
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
 }

--- a/src/public/sass/app-components/_side-nav.scss
+++ b/src/public/sass/app-components/_side-nav.scss
@@ -1,5 +1,5 @@
 .side-nav {
-
+	margin-bottom: govuk-em( 30, 16 );
 }
 
 .side-nav__item {

--- a/src/test/app/fake-data/backend/barriers/interactions-ordered.json
+++ b/src/test/app/fake-data/backend/barriers/interactions-ordered.json
@@ -1,0 +1,55 @@
+{
+   "count": 87559,
+   "results": [
+      {
+         "id": 1,
+         "kind": "libero",
+         "text": "sunt sequi aliquid",
+         "pinned": false,
+         "is_active": true,
+         "created_on": "Tue Sep 11 2018 06:16:40 GMT+0100 (BST)",
+         "barrier": "0a0f62a0-9de4-4b11-b9ab-93ad620c0508",
+         "created_by": "esse est laboriosam"
+      },
+      {
+         "id": 2,
+         "kind": "eum",
+         "text": "minus a quia",
+         "pinned": true,
+         "is_active": false,
+         "created_on": "Fri Jun 01 2018 01:43:07 GMT+0100 (BST)",
+         "barrier": "f48f9ed7-14cd-456a-bfdd-3f4632f46e80",
+         "created_by": "sit ea aut"
+      },
+      {
+         "id": 3,
+         "kind": "veniam",
+         "text": "eum ea tempora",
+         "pinned": false,
+         "is_active": true,
+         "created_on": "Thur Nov 22 2018 10:45:25 GMT+0000 (GMT)",
+         "barrier": "dd49b8b9-8e74-44e9-8824-ad867f4bee9a",
+         "created_by": "exercitationem omnis omnis"
+      },
+      {
+         "id": 4,
+         "kind": "possimus",
+         "text": "tempore nam nobis",
+         "pinned": true,
+         "is_active": true,
+         "created_on": "Sat Dec 08 2018 08:25:17 GMT+0000 (GMT)",
+         "barrier": "be5928bf-a2a0-4d62-abb7-f8e2e2918916",
+         "created_by": "in ipsa delectus"
+      },
+      {
+         "id": 5,
+         "kind": "enim",
+         "text": "reiciendis odio ipsa",
+         "pinned": true,
+         "is_active": true,
+         "created_on": "Sat Dec 08 2018 08:25:17 GMT+0000 (GMT)",
+         "barrier": "68c42128-7156-4fa9-bd53-da70333a5739",
+         "created_by": "ipsum velit temporibus"
+      }
+   ]
+}

--- a/src/test/app/fake-data/backend/barriers/status_history.json
+++ b/src/test/app/fake-data/backend/barriers/status_history.json
@@ -1,0 +1,64 @@
+{
+   "status_history": [
+      {
+         "date": "Thu Apr 19 2018 05:18:44 GMT+0100 (BST)",
+         "status_date": "Sun Apr 08 2018 08:49:42 GMT+0100 (BST)",
+         "event": "REPORT_CREATED",
+         "old_status": null,
+         "new_status": 0,
+         "status_summary": "praesentium reiciendis aut",
+         "user": {
+            "id": 6,
+            "name": "accusamus"
+         }
+      },
+      {
+         "date": "Wed May 02 2018 23:10:35 GMT+0100 (BST)",
+         "status_date": "Tue Apr 10 2018 10:00:36 GMT+0100 (BST)",
+         "event": "BARRIER_CREATED",
+         "old_status": 0,
+         "new_status": 2,
+         "status_summary": "exercitationem nobis eum",
+         "user": {
+            "id": 11,
+            "name": "aut"
+         }
+      },
+      {
+         "date": "Mon Nov 05 2018 17:58:16 GMT+0000 (GMT)",
+         "status_date": "Wed Nov 22 2017 22:43:57 GMT+0000 (GMT)",
+         "event": "BARRIER_STATUS_CHANGE",
+         "old_status": 4,
+         "new_status": 2,
+         "status_summary": "officiis ipsa eligendi",
+         "user": {
+            "id": 18,
+            "name": "nisi"
+         }
+      },
+      {
+         "date": "Wed Jun 13 2018 17:29:38 GMT+0100 (BST)",
+         "status_date": "Tue Mar 06 2018 02:23:36 GMT+0000 (GMT)",
+         "event": "BARRIER_STATUS_CHANGE",
+         "old_status": 2,
+         "new_status": 4,
+         "status_summary": "voluptatibus quia aspernatur",
+         "user": {
+            "id": 9,
+            "name": "voluptatem"
+         }
+      },
+      {
+         "date": "Wed Sep 05 2018 09:40:54 GMT+0100 (BST)",
+         "status_date": "Mon Jun 18 2018 15:19:15 GMT+0100 (BST)",
+         "event": "BARRIER_STATUS_CHANGE",
+         "old_status": 2,
+         "new_status": 5,
+         "status_summary": "consectetur deserunt velit",
+         "user": {
+            "id": 19,
+            "name": "aspernatur"
+         }
+      }
+   ]
+}


### PR DESCRIPTION
Add new schema for new API
Add new nunjucks filter to return the time of a timestamp
Refactor existing barrier interactions controller to split logic into a new interactions view model
Call two APIs in interactions controller and pass results to view model
Add new method to backend service
Update template to match designs with logic for status history