### PR TITLE
Fix bug where uploaded documents are not removed from the session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "5.8.2",
+  "version": "5.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "5.8.2",
+  "version": "5.8.3",
   "description": "A front end for Market Access",
   "main": "server.js",
   "engines": {

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -81,7 +81,7 @@ let config = {
 			},
 		},
 		scan: {
-			maxWaitTime: number( 'FILE_SCAN_MAX_WAIT_TIME', 15000 ),
+			maxWaitTime: number( 'FILE_SCAN_MAX_WAIT_TIME', 30000 ),
 			statusCheckInterval: number( 'FILE_SCAN_STATUS_CHECK_INTERVAL', 500 ),
 		},
 	},

--- a/src/app/sub-apps/barriers/controllers/interactions.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.js
@@ -294,13 +294,6 @@ module.exports = {
 
 						values.documentId = formValues.documentId;
 
-						if( req.session.barrierDocuments ){
-
-							req.session.barrierDocuments = req.session.barrierDocuments.filter( ( { barrierId, documentId } ) => (
-								barrierId === req.barrier.id && documentId === formValues.documentId
-							) );
-						}
-
 					} else if( formValues.document && formValues.document.size > 0 ){
 
 						try {
@@ -322,7 +315,17 @@ module.exports = {
 
 					return backend.barriers.notes.save( req, barrier.id, values );
 				},
-				saved: () => res.redirect( urls.barriers.interactions( barrier.id ) )
+				saved: () => {
+
+					if( req.session.barrierDocuments ){
+
+						req.session.barrierDocuments = req.session.barrierDocuments.filter( ( { barrierId } ) => (
+							barrierId !== barrier.id
+						) );
+					}
+
+					res.redirect( urls.barriers.interactions( barrier.id ) );
+				}
 			} );
 
 			try {

--- a/src/app/sub-apps/barriers/controllers/interactions.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.js
@@ -84,57 +84,65 @@ function uploadDocument( req, file ) {
 
 	return new Promise( async ( resolve, reject ) => {
 
-		const { response, body } = await backend.documents.create( req, file.name, file.size );
+		try {
 
-		if( response.isSuccess ){
+			const { response, body } = await backend.documents.create( req, file.name, file.size );
 
-			const { id, signed_upload_url } = body;
+			if( response.isSuccess ){
 
-			uploadFile( signed_upload_url, file ).then( async ( { response } ) => {
+				const { id, signed_upload_url } = body;
 
-				if( response.statusCode === 200 ){
+				uploadFile( signed_upload_url, file ).then( async ( { response } ) => {
 
-					const { response } = await backend.documents.uploadComplete( req, id );
+					if( response.statusCode === 200 ){
 
-					if( response.isSuccess ){
+						const { response } = await backend.documents.uploadComplete( req, id );
 
-						resolve( id );
+						if( response.isSuccess ){
+
+							resolve( id );
+
+						} else {
+
+							const err = new Error( 'Unable to complete upload' );
+
+							reject( err );
+							reporter.captureException( err, { response: {
+								statusCode: response.statusCode,
+								documentId: id,
+							} } );
+						}
 
 					} else {
 
-						const err = new Error( 'Unable to complete upload' );
+						const err = new Error( 'Unable to upload document to S3' );
 
 						reject( err );
-						reporter.captureException( err, { response: {
-							statusCode: response.statusCode,
-							documentId: id,
-						} } );
+						reporter.captureException( err, {
+							response: {
+								statusCode: response.statusCode,
+								body: response.body,
+								documentId: id,
+							}
+						} );
 					}
 
-				} else {
+				} ).catch( ( e ) => {
 
-					const err = new Error( 'Unable to upload document to S3' );
+					reject( e );
+					reporter.captureException( e, { documentId: id } );
+				} );
 
-					reject( err );
-					reporter.captureException( err, {
-						response: {
-							statusCode: response.statusCode,
-							body: response.body,
-							documentId: id,
-						}
-					} );
-				}
+			} else {
 
-			} ).catch( ( e ) => {
+				reject( new Error( 'Could not create document' ) );
+			}
 
-				reject( e );
-				reporter.captureException( e, { documentId: id } );
-			} );
+		} catch ( e ){
 
-		} else {
-
-			reject( new Error( 'Could not create document' ) );
+			reject( e );
 		}
+
 	} );
 }
 

--- a/src/app/sub-apps/barriers/controllers/interactions.spec.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.spec.js
@@ -372,25 +372,42 @@ describe( 'Barrier interactions controller', () => {
 				} );
 
 				describe( 'With a document', () => {
+
+					let config;
+					let formValues;
+					let signed_upload_url;
+					let documentId;
+
+					beforeEach( async () => {
+
+						await controller.notes.add( req, res, next );
+
+						config = FormProcessor.calls.argsFor( 0 )[ 0 ];
+						documentId = uuid();
+						signed_upload_url = 'a/b/c';
+						formValues = {
+							note: faker.lorem.words(),
+							pinned: true,
+							document: { name: 'a document', size: 12 },
+						};
+					} );
+
+					describe( 'When uploadDocument rejects', () => {
+						it( 'Should call next with an error', async () => {
+
+							const err = new Error( 'My test' );
+
+							backend.documents.create.and.callFake( () => Promise.reject( err ) );
+
+							await config.saveFormData( formValues );
+
+							expect( next ).toHaveBeenCalledWith( err );
+						} );
+					} );
+
 					describe( 'When uploadDocument returns success', () => {
 
-						let config;
-						let formValues;
-						let signed_upload_url;
-						let documentId;
-
-						beforeEach( async () => {
-
-							await controller.notes.add( req, res, next );
-
-							config = FormProcessor.calls.argsFor( 0 )[ 0 ];
-							documentId = uuid();
-							signed_upload_url = 'a/b/c';
-							formValues = {
-								note: faker.lorem.words(),
-								pinned: true,
-								document: { name: 'a document', size: 12 },
-							};
+						beforeEach( () => {
 
 							backend.documents.create.and.callFake( () => Promise.resolve( { response: {
 								isSuccess: true

--- a/src/app/sub-apps/barriers/controllers/interactions.spec.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.spec.js
@@ -315,18 +315,23 @@ describe( 'Barrier interactions controller', () => {
 				} );
 
 				describe( 'With a documentId', () => {
-					it( 'Should configure the saveFormData correctly', async () => {
+
+					let config;
+					let formValues;
+
+					beforeEach( async () => {
 
 						await controller.notes.add( req, res, next );
 
-						const config = FormProcessor.calls.argsFor( 0 )[ 0 ];
-						const formValues = {
+						config = FormProcessor.calls.argsFor( 0 )[ 0 ];
+						formValues = {
 							note: faker.lorem.words(),
 							pinned: true,
 							documentId: uuid(),
 						};
+					} );
 
-						config.saveFormData( formValues );
+					afterEach( () => {
 
 						expect( backend.barriers.notes.save ).toHaveBeenCalledWith( req, req.barrier.id, {
 							note: formValues.note,
@@ -336,18 +341,52 @@ describe( 'Barrier interactions controller', () => {
 
 						expect( next ).not.toHaveBeenCalled();
 					} );
+
+					describe( 'When there are documents in the session', () => {
+						it( 'Should remove the documents for this barrier id', () => {
+
+							const doc1 = { barrierId: uuid(), documentId: uuid() };
+							const doc2 = { barrierId: uuid(), documentId: uuid() };
+
+							req.session.barrierDocuments = [
+								doc1,
+								{ barrierId: barrier.id, documentId: formValues.documentId },
+								doc2,
+							];
+
+							config.saveFormData( formValues );
+							config.saved();
+
+							expect( req.session.barrierDocuments ).toEqual( [
+								doc1, doc2
+							] );
+						} );
+					} );
+
+					describe( 'When there are not any documents in the session', () => {
+						it( 'Should configure the saveFormData correctly', async () => {
+
+							config.saveFormData( formValues );
+						} );
+					} );
 				} );
 
 				describe( 'With a document', () => {
-					describe( 'When uploadDocument and getScanStatus return success', () => {
-						it( 'Should configure the saveFormData correctly', async () => {
+					describe( 'When uploadDocument returns success', () => {
+
+						let config;
+						let formValues;
+						let signed_upload_url;
+						let documentId;
+
+						beforeEach( async () => {
 
 							await controller.notes.add( req, res, next );
 
-							const config = FormProcessor.calls.argsFor( 0 )[ 0 ];
-							const documentId = uuid();
-							const signed_upload_url = 'a/b/c';
-							const formValues = {
+							config = FormProcessor.calls.argsFor( 0 )[ 0 ];
+							documentId = uuid();
+							signed_upload_url = 'a/b/c';
+							formValues = {
 								note: faker.lorem.words(),
 								pinned: true,
 								document: { name: 'a document', size: 12 },
@@ -367,24 +406,47 @@ describe( 'Barrier interactions controller', () => {
 							backend.documents.uploadComplete.and.callFake( () => Promise.resolve( {
 								response: { isSuccess: true },
 							} ) );
+						} );
 
-							backend.documents.getScanStatus.and.callFake( () => Promise.resolve( {
-								status: 'virus_scanned',
-								passed: true,
-							} ) );
-
-							await config.saveFormData( formValues );
+						afterEach( () => {
 
 							expect( backend.documents.create ).toHaveBeenCalledWith( req, formValues.document.name, formValues.document.size );
 							expect( uploadFile ).toHaveBeenCalledWith( signed_upload_url, formValues.document );
 							expect( backend.documents.uploadComplete ).toHaveBeenCalledWith( req, documentId );
 							expect( backend.documents.getScanStatus ).toHaveBeenCalledWith( req, documentId );
-							expect( backend.barriers.notes.save ).toHaveBeenCalledWith( req, req.barrier.id, {
-								note: formValues.note,
-								pinned: formValues.pinned,
-								documentId
+						} );
+
+						describe( 'When getScanStatus return success', () => {
+							it( 'Should configure the saveFormData correctly', async () => {
+
+								backend.documents.getScanStatus.and.callFake( () => Promise.resolve( {
+									status: 'virus_scanned',
+									passed: true,
+								} ) );
+
+								await config.saveFormData( formValues );
+
+								expect( backend.barriers.notes.save ).toHaveBeenCalledWith( req, req.barrier.id, {
+									note: formValues.note,
+									pinned: formValues.pinned,
+									documentId
+								} );
+								expect( next ).not.toHaveBeenCalled();
 							} );
-							expect( next ).not.toHaveBeenCalled();
+						} );
+
+						describe( 'When getScanStatus returns pass false', () => {
+							it( 'Should throw an error', async () => {
+
+								backend.documents.getScanStatus.and.callFake( () => Promise.resolve( {
+									status: 'virus_scanned',
+									passed: false,
+								} ) );
+
+								await config.saveFormData( formValues );
+
+								expect( next ).toHaveBeenCalledWith( new Error( 'This file may be infected with a virus and will not be accepted.' ) );
+							} );
 						} );
 					} );
 				} );

--- a/src/public/js/pages/barrier/interactions/add-note.js
+++ b/src/public/js/pages/barrier/interactions/add-note.js
@@ -37,6 +37,13 @@ ma.pages.barrier.interactions.addNote = (function( doc, jessie ){
 
 		var deleteUrl = jessie.getElementData( form, 'xhr-delete' );
 
+		function showError( message ){
+
+			submit.disabled = false;
+			fileUpload.setError( message );
+			fileUpload.showLink();
+		}
+
 		function setDocumentId( id ){
 
 			if( !documentIdInput ){
@@ -66,13 +73,11 @@ ma.pages.barrier.interactions.addNote = (function( doc, jessie ){
 		}
 
 		function transferFailed(){
-			fileUpload.setError( 'Upload of document cancelled, try again.' );
-			fileUpload.showLink();
+			showError( 'Upload of document cancelled, try again.' );
 		}
 
 		function transferCanceled(){
-			fileUpload.setError( 'Upload of document cancelled, try again.' );
-			fileUpload.showLink();
+			showError( 'Upload of document cancelled, try again.' );
 		}
 
 		function checkFileStatus( file, url, documentId ){
@@ -101,19 +106,18 @@ ma.pages.barrier.interactions.addNote = (function( doc, jessie ){
 
 					if( !passed ){
 
-						fileUpload.setError( 'This file may be infected with a virus and will not be accepted.' );
-						fileUpload.showLink();
+						showError( 'This file may be infected with a virus and will not be accepted.' );
 						return;
 					}
 
+					submit.disabled = false;
 					fileUpload.setFile( file );
 					setDocumentId( documentId );
 
 				} else {
 
-					var message = ( data.message || 'A system error has occured, so the file has not been uploaded. Try again.' );
-					fileUpload.setError( message );
-					fileUpload.showLink();
+					var message = ( ( data && data.message ) || 'A system error has occured, so the file has not been uploaded. Try again.' );
+					showError( message );
 				}
 
 			}, false );
@@ -127,8 +131,6 @@ ma.pages.barrier.interactions.addNote = (function( doc, jessie ){
 			var xhr = e.target;
 			var responseCode = xhr.status;
 			var data;
-
-			submit.disabled = false;
 
 			try {
 
@@ -152,15 +154,13 @@ ma.pages.barrier.interactions.addNote = (function( doc, jessie ){
 
 				} else {
 
-					fileUpload.setError( 'There was an issue uploading the document, try again' );
-					fileUpload.showLink();
+					showError( 'There was an issue uploading the document, try again' );
 				}
 
 			} else {
 
 				var message = ( data.message || 'A system error has occured, so the file has not been uploaded. Try again.' );
-				fileUpload.setError( message );
-				fileUpload.showLink();
+				showError( message );
 			}
 		}
 


### PR DESCRIPTION
If a user uploaded a document any subsequent note created in the session would also have the same document added to it. This adds code with a test to ensure the session documents are cleared when the note is saved.
Also increase time to wait for a virus scan from 15 seconds to 30