### PR TITLE
Remove double Sentry reporting bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "5.8.4",
+  "version": "5.8.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "5.8.4",
+  "version": "5.8.5",
   "description": "A front end for Market Access",
   "main": "server.js",
   "engines": {

--- a/src/app/middleware/errors.js
+++ b/src/app/middleware/errors.js
@@ -1,5 +1,4 @@
 const config = require( '../config' );
-const reporter = require( '../lib/reporter' );
 
 module.exports = {
 
@@ -11,10 +10,14 @@ module.exports = {
 
 	catchAll: function( err, req, res, next ){
 
+		/*
+		As this middleware is called after the reporter (raven/sentry) we do not need to report errors
+		If we were to call reporter.captureException here it would result it two errors being reported to Sentry
+		*/
+
 		if( res.headersSent ){
 
 			next( err );
-			reporter.captureException( err );
 
 		} else {
 
@@ -31,7 +34,6 @@ module.exports = {
 
 				res.status( 500 );
 				res.render( 'error/default', { error: err, showErrors: config.showErrors } );
-				reporter.captureException( err );
 			}
 		}
 	}

--- a/src/app/middleware/errors.spec.js
+++ b/src/app/middleware/errors.spec.js
@@ -51,7 +51,7 @@ describe( 'errors middleware', function(){
 
 					expect( res.status ).not.toHaveBeenCalled();
 					expect( res.render ).not.toHaveBeenCalled();
-					expect( reporter.captureException ).toHaveBeenCalledWith( err );
+					expect( reporter.captureException ).not.toHaveBeenCalled();
 					expect( next ).toHaveBeenCalledWith( err );
 				} );
 			} );
@@ -64,7 +64,7 @@ describe( 'errors middleware', function(){
 
 						expect( res.status ).toHaveBeenCalledWith( 500 );
 						expect( res.render ).toHaveBeenCalledWith( 'error/default', { showErrors: config.showErrors, error: err } );
-						expect( reporter.captureException ).toHaveBeenCalledWith( err );
+						expect( reporter.captureException ).not.toHaveBeenCalled();
 						expect( next ).not.toHaveBeenCalled();
 					} );
 				} );


### PR DESCRIPTION
I had previously called the reporter in the catchAll method, but this resulted in two errors in Sentry. As the middleware is after the reporter.handleErrors it is not necessary to report the errors in the catchAll method.