### PR TITLE
Tweak width for tablets and above

### DIFF
--- a/src/public/sass/pages/_find-a-barrier.scss
+++ b/src/public/sass/pages/_find-a-barrier.scss
@@ -112,5 +112,6 @@
 
 	@include mq( $from: tablet ){
 		margin-bottom: 0;
+		width: 65%;
 	}
 }


### PR DESCRIPTION
so the sectors and barrier location stay on one line each