### PR TITLE
Set default sort order for dashboard and find a barrier

### DIFF
--- a/src/app/app.spec.js
+++ b/src/app/app.spec.js
@@ -137,7 +137,7 @@ describe( 'App', function(){
 			it( 'Should render the index page', function( done ){
 
 				intercept.backend()
-					.get( /\/barriers(\?country=[a-z0-9-]+)?$/ )
+					.get( /^\/barriers(\?.+)?$/ )
 					.reply( 200, intercept.stub( '/backend/barriers/' ) );
 
 				app
@@ -168,7 +168,7 @@ describe( 'App', function(){
 			it( 'Should render the page', function( done ){
 
 				intercept.backend()
-					.get( `/barriers` )
+					.get( /^\/barriers(\?.+?)?$/ )
 					.reply( 200, intercept.stub( '/backend/barriers/' ) );
 
 				app
@@ -610,7 +610,7 @@ describe( 'App', function(){
 				it( 'Should render a list of reports', ( done ) => {
 
 					intercept.backend()
-					.get( '/reports' )
+					.get( /^\/reports(\?.+)?$/ )
 					.reply( 200, intercept.stub( '/backend/reports/' ) );
 
 					app

--- a/src/app/controllers/index.js
+++ b/src/app/controllers/index.js
@@ -9,7 +9,9 @@ module.exports = {
 		const country = req.user.country;
 		const countryId = country && req.user.country.id;
 		let template = 'index';
-		const filters = {};
+		const filters = {
+			status: '2,5'
+		};
 
 		if( countryId ){
 

--- a/src/app/controllers/index.spec.js
+++ b/src/app/controllers/index.spec.js
@@ -79,7 +79,7 @@ describe( 'Index controller', () => {
 						await controller.index( req, res, next );
 
 						expect( next ).not.toHaveBeenCalled();
-						expect( backend.barriers.getAll ).toHaveBeenCalledWith( req, { country: country.id } );
+						expect( backend.barriers.getAll ).toHaveBeenCalledWith( req, { country: country.id, status: '2,5' } );
 						expect( dashboardViewModel ).toHaveBeenCalledWith( barriersResponse.body.results, country );
 						expect( res.render ).toHaveBeenCalledWith( 'my-country', dashboardViewModelResponse );
 					} );
@@ -102,7 +102,7 @@ describe( 'Index controller', () => {
 						await controller.index( req, res, next );
 
 						expect( next ).not.toHaveBeenCalled();
-						expect( backend.barriers.getAll ).toHaveBeenCalledWith( req, {} );
+						expect( backend.barriers.getAll ).toHaveBeenCalledWith( req, { status: '2,5' } );
 						expect( dashboardViewModel ).toHaveBeenCalledWith( barriersResponse.body.results, req.user.country );
 						expect( res.render ).toHaveBeenCalledWith( 'index', dashboardViewModelResponse );
 					} );
@@ -122,7 +122,7 @@ describe( 'Index controller', () => {
 					await controller.index( req, res, next );
 
 					expect( next ).toHaveBeenCalledWith( new Error( `Got ${ barriersResponse.response.statusCode } response from backend` ) );
-					expect( backend.barriers.getAll ).toHaveBeenCalledWith( req, {} );
+					expect( backend.barriers.getAll ).toHaveBeenCalledWith( req, { status: '2,5' } );
 					expect( res.render ).not.toHaveBeenCalled();
 				} );
 			} );

--- a/src/app/lib/backend-service.js
+++ b/src/app/lib/backend-service.js
@@ -214,7 +214,7 @@ module.exports = {
 			const params = getFilterParams( filters );
 			let path = '/barriers';
 
-			params.push( 'ordering=reported_on' );
+			params.push( 'ordering=-reported_on' );
 
 			if( params.length ){
 
@@ -281,8 +281,8 @@ module.exports = {
 
 	reports: {
 		...reports,
-		getAll: ( req ) => backend.get( '/reports?ordering=created_on', getToken( req ) ).then( transformReportList ),
-		getForCountry: ( req, countryId ) => backend.get( `/reports?export_country=${ countryId }&ordering=created_on`, getToken( req ) ).then( transformReportList ),
+		getAll: ( req ) => backend.get( '/reports?ordering=-created_on', getToken( req ) ).then( transformReportList ),
+		getForCountry: ( req, countryId ) => backend.get( `/reports?export_country=${ countryId }&ordering=-created_on`, getToken( req ) ).then( transformReportList ),
 		get: ( req, reportId ) => backend.get( `/reports/${ reportId }`, getToken( req ) ).then( transformSingleReport ),
 		save: ( req, values ) => backend.post( '/reports', getToken( req ), {
 			problem_status: getValue( values.status ),

--- a/src/app/lib/backend-service.js
+++ b/src/app/lib/backend-service.js
@@ -120,6 +120,7 @@ function getFilterParams( filters ){
 		'export_country': 'country',
 		'sector': 'sector',
 		'barrier_type': 'type',
+		'status': 'status'
 		//'start_date': 'date-start',
 		//'end_date': 'date-end',
 	};
@@ -213,6 +214,8 @@ module.exports = {
 			const params = getFilterParams( filters );
 			let path = '/barriers';
 
+			params.push( 'ordering=reported_on' );
+
 			if( params.length ){
 
 				path += '?' + params.join( '&' );
@@ -278,8 +281,8 @@ module.exports = {
 
 	reports: {
 		...reports,
-		getAll: ( req ) => backend.get( '/reports', getToken( req ) ).then( transformReportList ),
-		getForCountry: ( req, countryId ) => backend.get( `/reports?export_country=${ countryId }`, getToken( req ) ).then( transformReportList ),
+		getAll: ( req ) => backend.get( '/reports?ordering=created_on', getToken( req ) ).then( transformReportList ),
+		getForCountry: ( req, countryId ) => backend.get( `/reports?export_country=${ countryId }&ordering=created_on`, getToken( req ) ).then( transformReportList ),
 		get: ( req, reportId ) => backend.get( `/reports/${ reportId }`, getToken( req ) ).then( transformSingleReport ),
 		save: ( req, values ) => backend.post( '/reports', getToken( req ), {
 			problem_status: getValue( values.status ),

--- a/src/app/lib/backend-service.spec.js
+++ b/src/app/lib/backend-service.spec.js
@@ -172,44 +172,55 @@ describe( 'Backend Service', () => {
 
 		describe( 'getAll', () => {
 			describe( 'With no filters', () => {
-				it( 'Should call the correct path', async () => {
+				it( 'Should call the correct path with default sort order', async () => {
 
 					await service.barriers.getAll( req );
 
-					expect( backend.get ).toHaveBeenCalledWith( '/barriers', token );
+					expect( backend.get ).toHaveBeenCalledWith( '/barriers?ordering=reported_on', token );
 				} );
 			} );
 
 			describe( 'With a country filter', () => {
-				it( 'Should call the correct path', async () => {
+				it( 'Should call the correct path with default sort order', async () => {
 
 					const country = uuid();
 
 					await service.barriers.getAll( req, { country } );
 
-					expect( backend.get ).toHaveBeenCalledWith( `/barriers?export_country=${ country }`, token );
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers?export_country=${ country }&ordering=reported_on`, token );
 				} );
 			} );
 
 			describe( 'With a sector filter', () => {
-				it( 'Should call the correct path', async () => {
+				it( 'Should call the correct path with default sort order', async () => {
 
 					const sector = uuid();
 
 					await service.barriers.getAll( req, { sector } );
 
-					expect( backend.get ).toHaveBeenCalledWith( `/barriers?sector=${ sector }`, token );
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers?sector=${ sector }&ordering=reported_on`, token );
 				} );
 			} );
 
 			describe( 'With a type filter', () => {
-				it( 'Should call the correct path', async () => {
+				it( 'Should call the correct path with default sort order', async () => {
 
 					const type = faker.lorem.word().toUpperCase();
 
 					await service.barriers.getAll( req, { type } );
 
-					expect( backend.get ).toHaveBeenCalledWith( `/barriers?barrier_type=${ type }`, token );
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers?barrier_type=${ type }&ordering=reported_on`, token );
+				} );
+			} );
+
+			describe( 'With a status filter', () => {
+				it( 'Should call the correct path with default sort order', async () => {
+
+					const status = '2,5';
+
+					await service.barriers.getAll( req, { status } );
+
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers?status=${ status }&ordering=reported_on`, token );
 				} );
 			} );
 		} );
@@ -569,7 +580,7 @@ describe( 'Backend Service', () => {
 
 					const { body } = await service.reports.getAll( req );
 
-					expect( backend.get ).toHaveBeenCalledWith( '/reports', token );
+					expect( backend.get ).toHaveBeenCalledWith( '/reports?ordering=created_on', token );
 					expect( body.results[ 0 ].progress.map( ( item ) => item.stage_code ) ).toEqual( [ '1.3', '1.4', '1.4', '1.5', '2.4', '2.5', '3', '3.1' ] );
 				} );
 			} );
@@ -586,7 +597,7 @@ describe( 'Backend Service', () => {
 
 					await service.reports.getAll( req );
 
-					expect( backend.get ).toHaveBeenCalledWith( '/reports', token );
+					expect( backend.get ).toHaveBeenCalledWith( '/reports?ordering=created_on', token );
 				} );
 			} );
 		} );
@@ -594,7 +605,7 @@ describe( 'Backend Service', () => {
 		describe( 'getForCountry', () => {
 
 			const countryId = 'def-789';
-			const countryUrl = `/reports?export_country=${ countryId }`;
+			const countryUrl = `/reports?export_country=${ countryId }&ordering=created_on`;
 
 			describe( 'When the results are an array', () => {
 				it( 'Should call the correct path and sort the progress', async () => {

--- a/src/app/lib/backend-service.spec.js
+++ b/src/app/lib/backend-service.spec.js
@@ -176,7 +176,7 @@ describe( 'Backend Service', () => {
 
 					await service.barriers.getAll( req );
 
-					expect( backend.get ).toHaveBeenCalledWith( '/barriers?ordering=reported_on', token );
+					expect( backend.get ).toHaveBeenCalledWith( '/barriers?ordering=-reported_on', token );
 				} );
 			} );
 
@@ -187,7 +187,7 @@ describe( 'Backend Service', () => {
 
 					await service.barriers.getAll( req, { country } );
 
-					expect( backend.get ).toHaveBeenCalledWith( `/barriers?export_country=${ country }&ordering=reported_on`, token );
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers?export_country=${ country }&ordering=-reported_on`, token );
 				} );
 			} );
 
@@ -198,7 +198,7 @@ describe( 'Backend Service', () => {
 
 					await service.barriers.getAll( req, { sector } );
 
-					expect( backend.get ).toHaveBeenCalledWith( `/barriers?sector=${ sector }&ordering=reported_on`, token );
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers?sector=${ sector }&ordering=-reported_on`, token );
 				} );
 			} );
 
@@ -209,7 +209,7 @@ describe( 'Backend Service', () => {
 
 					await service.barriers.getAll( req, { type } );
 
-					expect( backend.get ).toHaveBeenCalledWith( `/barriers?barrier_type=${ type }&ordering=reported_on`, token );
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers?barrier_type=${ type }&ordering=-reported_on`, token );
 				} );
 			} );
 
@@ -220,7 +220,7 @@ describe( 'Backend Service', () => {
 
 					await service.barriers.getAll( req, { status } );
 
-					expect( backend.get ).toHaveBeenCalledWith( `/barriers?status=${ status }&ordering=reported_on`, token );
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers?status=${ status }&ordering=-reported_on`, token );
 				} );
 			} );
 		} );
@@ -580,7 +580,7 @@ describe( 'Backend Service', () => {
 
 					const { body } = await service.reports.getAll( req );
 
-					expect( backend.get ).toHaveBeenCalledWith( '/reports?ordering=created_on', token );
+					expect( backend.get ).toHaveBeenCalledWith( '/reports?ordering=-created_on', token );
 					expect( body.results[ 0 ].progress.map( ( item ) => item.stage_code ) ).toEqual( [ '1.3', '1.4', '1.4', '1.5', '2.4', '2.5', '3', '3.1' ] );
 				} );
 			} );
@@ -597,7 +597,7 @@ describe( 'Backend Service', () => {
 
 					await service.reports.getAll( req );
 
-					expect( backend.get ).toHaveBeenCalledWith( '/reports?ordering=created_on', token );
+					expect( backend.get ).toHaveBeenCalledWith( '/reports?ordering=-created_on', token );
 				} );
 			} );
 		} );
@@ -605,7 +605,7 @@ describe( 'Backend Service', () => {
 		describe( 'getForCountry', () => {
 
 			const countryId = 'def-789';
-			const countryUrl = `/reports?export_country=${ countryId }&ordering=created_on`;
+			const countryUrl = `/reports?export_country=${ countryId }&ordering=-created_on`;
 
 			describe( 'When the results are an array', () => {
 				it( 'Should call the correct path and sort the progress', async () => {

--- a/src/app/sub-apps/reports/view-models/reports.js
+++ b/src/app/sub-apps/reports/view-models/reports.js
@@ -17,22 +17,12 @@ function update( item ){
 	return item;
 }
 
-function sortDescending( a, b ){
-
-	const aDate = Date.parse( a.date.created );
-	const bDate = Date.parse( b.date.created );
-
-	return ( aDate === bDate ? 0 : ( aDate > bDate ? -1 : 1 ) );
-}
-
 module.exports = ( reports, country ) => {
 
 	if( reports && reports.length ){
 
 		reports = reports.map( update );
 	}
-
-	reports.sort( sortDescending );
 
 	return {	reports, country };
 };

--- a/src/app/sub-apps/reports/view-models/reports.spec.js
+++ b/src/app/sub-apps/reports/view-models/reports.spec.js
@@ -101,7 +101,7 @@ describe( 'Reports view model', () => {
 			}
 		} );
 
-		it( 'Should sort them', () => {
+		it( 'Should not sort them', () => {
 
 			reports[ 3 ].created_on = 'Thur, 30 Aug 2018 08:19:05 GMT';
 			reports[ 0 ].created_on = 'Tue, 28 Aug 2018 08:19:05 GMT';
@@ -110,10 +110,10 @@ describe( 'Reports view model', () => {
 
 			const output = viewModel( getReports() );
 
-			expect( output.reports[ 0 ].id ).toEqual( 4 );
-			expect( output.reports[ 1 ].id ).toEqual( 1 );
+			expect( output.reports[ 0 ].id ).toEqual( 1 );
+			expect( output.reports[ 1 ].id ).toEqual( 2 );
 			expect( output.reports[ 2 ].id ).toEqual( 3 );
-			expect( output.reports[ 3 ].id ).toEqual( 2 );
+			expect( output.reports[ 3 ].id ).toEqual( 4 );
 		} );
 	} );
 

--- a/src/app/view-models/dashboard.js
+++ b/src/app/view-models/dashboard.js
@@ -41,21 +41,11 @@ function update( barrier ){
 	};
 }
 
-function sortDescending( a, b ){
-
-	const aDate = Date.parse( a.date.reported );
-	const bDate = Date.parse( b.date.reported );
-
-	return ( aDate === bDate ? 0 : ( aDate > bDate ? -1 : 1 ) );
-}
-
 module.exports = ( barriers, country ) => {
 
 	if( barriers && barriers.length ){
 
 		barriers = barriers.map( update );
-
-		barriers.sort( sortDescending );
 	}
 
 	return {	barriers, country	};

--- a/src/app/view-models/dashboard.spec.js
+++ b/src/app/view-models/dashboard.spec.js
@@ -40,7 +40,7 @@ describe( 'Dashboard view model', () => {
 	} );
 
 	describe( 'When there are some barriers', () => {
-		it( 'Should transform and sort them', () => {
+		it( 'Should transform and not sort them', () => {
 
 			const barriers = jasmine.helpers.getFakeData( '/backend/barriers/index.dashboard' ).results;
 			const output = viewModel( JSON.parse( JSON.stringify( barriers ) ) );
@@ -79,7 +79,7 @@ describe( 'Dashboard view model', () => {
 				} );
 			}
 
-			[ '1ec', '648', '7de', '553' ].forEach( checkBarrier );
+			[ '7de', '1ec', '648', '553' ].forEach( checkBarrier );
 		} );
 	} );
 

--- a/src/app/views/find-a-barrier.njk
+++ b/src/app/views/find-a-barrier.njk
@@ -91,13 +91,7 @@
 								<span class="visually-hidden">ID: </span>{{ barrier.code }}
 							</li>
 							<li class="filter-results-list__item__sub-content__item">
-								{% if barrier.isResolved %}
-								<span class="muted">Resolved </span>{{ barrier.date.status | dateOnly( { day: false } ) }}
-								{% elif barrier.isHibernated %}
-								<span class="muted">Paused </span>{{ barrier.date.status | dateOnly( { day: false } ) }}
-								{% else %}
 								<span class="muted">Added </span>{{ barrier.date.reported | dateOnly }}
-								{% endif %}
 							</li>
 						</ul>
 					</li>


### PR DESCRIPTION
Update backend service to set default sort order for getting barriers and reports
  Also allow status as a filter
Specify status filter on dashboard
Remove sorting from dashboard and reports view models