### PR TITLE
HOTFIX: Show correct total on all barriers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "description": "A front end for Market Access",
   "main": "server.js",
   "engines": {

--- a/src/app/middleware/dashboard-data.js
+++ b/src/app/middleware/dashboard-data.js
@@ -28,7 +28,7 @@ module.exports = async ( req, res, next ) => {
 			const user = body.user;
 			const reports = body.reports;
 
-			all = ( barriers && barriers.total );
+			all = ( barriers && ( ( barriers.paused || 0 ) + barriers.open ) );
 			country = ( user && user.country );
 			unfinished = reports;
 

--- a/src/app/middleware/dashboard-data.spec.js
+++ b/src/app/middleware/dashboard-data.spec.js
@@ -44,11 +44,15 @@ describe( 'Dashboard tabs', () => {
 
 		describe( 'When all counts have a number', () => {
 
+			let fakeData;
+
 			beforeEach( () => {
+
+				fakeData = jasmine.helpers.getFakeData( '/backend/counts/' );
 
 				backend.getCounts.and.callFake( () => Promise.resolve( {
 					response: { isSuccess: true },
-					body: jasmine.helpers.getFakeData( '/backend/counts/' )
+					body: fakeData
 				} ) );
 			} );
 
@@ -72,34 +76,54 @@ describe( 'Dashboard tabs', () => {
 			} );
 
 			describe( 'When the user does NOT have a country', () => {
-				it( 'Should add an all property', async () => {
 
-					await middleware( req, res, next );
+				afterEach( () => {
 
 					expect( res.locals.dashboard.tabs.country.skip ).toEqual( true );
 
 					expect( res.locals.dashboard.tabs.all ).toBeDefined();
 					expect( res.locals.dashboard.tabs.all.skip ).toEqual( false );
-					expect( res.locals.dashboard.tabs.all.count ).toEqual( 22 );
 
 					expect( res.locals.dashboard.tabs.unfinished ).toBeDefined();
 					expect( res.locals.dashboard.tabs.unfinished.skip ).toEqual( false );
 					expect( res.locals.dashboard.tabs.unfinished.count ).toEqual( 15 );
+				} );
+
+				describe( 'When there are no paused numbers (old API)', () => {
+					it( 'Should add an all property with the open number', async () => {
+
+						delete fakeData.barriers.paused;
+
+						await middleware( req, res, next );
+
+						expect( res.locals.dashboard.tabs.all.count ).toEqual( 5 );
+					} );
+				} );
+
+				describe( 'When there are paused numbers', () => {
+					it( 'Should add an all property with the open and paused numbers added together', async () => {
+
+						await middleware( req, res, next );
+
+						expect( res.locals.dashboard.tabs.all.count ).toEqual( 15 );
+					} );
 				} );
 			} );
 		} );
 
 		describe( 'When unfinished has a 0 count', () => {
 
+			let fakeData;
+
 			beforeEach( () => {
 
-				const body = jasmine.helpers.getFakeData( '/backend/counts/' );
+				fakeData = jasmine.helpers.getFakeData( '/backend/counts/' );
 
-				body.reports = 0;
+				fakeData.reports = 0;
 
 				backend.getCounts.and.callFake( () => Promise.resolve( {
 					response: { isSuccess: true },
-					body
+					body: fakeData
 				} ) );
 			} );
 
@@ -123,19 +147,37 @@ describe( 'Dashboard tabs', () => {
 			} );
 
 			describe( 'When the user does NOT have a country', () => {
-				it( 'Should add an all property', async () => {
 
-					await middleware( req, res, next );
+				afterEach( () => {
 
 					expect( res.locals.dashboard.tabs.country.skip ).toEqual( true );
 
 					expect( res.locals.dashboard.tabs.all ).toBeDefined();
 					expect( res.locals.dashboard.tabs.all.skip ).toEqual( false );
-					expect( res.locals.dashboard.tabs.all.count ).toEqual( 22 );
 
 					expect( res.locals.dashboard.tabs.unfinished ).toBeDefined();
 					expect( res.locals.dashboard.tabs.unfinished.skip ).toEqual( true );
 					expect( res.locals.dashboard.tabs.unfinished.count ).toEqual( 0 );
+				} );
+
+				describe( 'When there are no paused numbers (old API)', () => {
+					it( 'Should add an all property with the open number', async () => {
+
+						delete fakeData.barriers.paused;
+
+						await middleware( req, res, next );
+
+						expect( res.locals.dashboard.tabs.all.count ).toEqual( 5 );
+					} );
+				} );
+
+				describe( 'When there are paused numbers', () => {
+					it( 'Should add an all property with the open and paused numbers added together', async () => {
+
+						await middleware( req, res, next );
+
+						expect( res.locals.dashboard.tabs.all.count ).toEqual( 15 );
+					} );
 				} );
 			} );
 		} );

--- a/src/data/schema/backend/counts/index.json
+++ b/src/data/schema/backend/counts/index.json
@@ -15,12 +15,14 @@
 			"required": [
 				"total",
 				"open",
+				"paused",
 				"resolved"
 			],
 			"properties": {
 
 				"total": { "$ref": "$refs/common.json#/small-int" },
 				"open": { "$ref": "$refs/common.json#/small-int" },
+				"paused": { "$ref": "$refs/common.json#/small-int" },
 				"resolved": { "$ref": "$refs/common.json#/small-int" }
 			}
 		},

--- a/src/test/app/fake-data/backend/counts/index.json
+++ b/src/test/app/fake-data/backend/counts/index.json
@@ -1,7 +1,8 @@
 {
    "barriers": {
       "total": 22,
-      "open": 5,
+		"open": 5,
+		"paused": 10,
       "resolved": 17
    },
    "reports": 15,


### PR DESCRIPTION
All barriers currently shows the incorrect total, it shoud be paused and open excluding resolved
This fix will add the open and paused together
  Paused is defaulted to 0 until the API gets updated
Also update schema to reflect API changes