### PR TITLE
Handle missing answer error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "5.12.1",
+  "version": "5.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "5.12.1",
+  "version": "5.12.2",
   "description": "A front end for Market Access",
   "main": "server.js",
   "engines": {

--- a/src/app/lib/FormProcessor.js
+++ b/src/app/lib/FormProcessor.js
@@ -38,6 +38,10 @@ FormPocessor.prototype.doSave = async function( checkResponseErrors = false ){
 		const err = new Error( `Unable to save form - got ${ response.statusCode } from backend` );
 		err.responseBody = body;
 
+		if( response.statusCode === 400 ){
+			err.code = 'UNHANDLED_400';
+		}
+
 		throw err;
 	}
 };

--- a/src/app/lib/FormProcessor.spec.js
+++ b/src/app/lib/FormProcessor.spec.js
@@ -123,11 +123,11 @@ describe( 'FormProcessor', () => {
 						response = { isSuccess: false, statusCode: 400 };
 					} );
 
-					async function runProcessor(){
+					async function runProcessor( checkResponseErrors = true ){
 
 						try {
 
-							await processor.process( { checkResponseErrors: true } );
+							await processor.process( { checkResponseErrors } );
 
 						} catch( e ){
 
@@ -148,6 +148,7 @@ describe( 'FormProcessor', () => {
 
 								expect( render ).not.toHaveBeenCalled();
 								expect( err ).toEqual( new Error( 'Unable to save form - got 400 from backend' ) );
+								expect( err.code ).toEqual( 'UNHANDLED_400' );
 							} );
 						} );
 
@@ -163,6 +164,7 @@ describe( 'FormProcessor', () => {
 
 								expect( render ).not.toHaveBeenCalled();
 								expect( err ).toEqual( new Error( 'Unable to save form - got 400 from backend' ) );
+								expect( err.code ).toEqual( 'UNHANDLED_400' );
 							} );
 						} );
 
@@ -197,8 +199,25 @@ describe( 'FormProcessor', () => {
 
 									expect( render ).not.toHaveBeenCalled();
 									expect( err ).toEqual( new Error( 'No errors in response body, form not saved - got 400 from backend' ) );
+									expect( err.code ).not.toBeDefined();
 								} );
 							} );
+						} );
+					} );
+
+					describe( 'When checkResponseErrors is false', () => {
+						it( 'Should throw an error', async () => {
+
+							saveFormData.and.callFake( () => ({
+								response,
+								body: { fields: { a: 1, b: 2 } }
+							}) );
+
+							await runProcessor( false );
+
+							expect( render ).not.toHaveBeenCalled();
+							expect( err ).toEqual( new Error( 'Unable to save form - got 400 from backend' ) );
+							expect( err.code ).toEqual( 'UNHANDLED_400' );
 						} );
 					} );
 				} );

--- a/src/app/sub-apps/reports/controllers/summary.js
+++ b/src/app/sub-apps/reports/controllers/summary.js
@@ -4,6 +4,14 @@ const FormProcessor = require( '../../../lib/FormProcessor' );
 const urls = require( '../../../lib/urls' );
 const config = require( '../../../config' );
 
+function isEuExitRequired( body ){
+
+	const messages = body && body.eu_exit_related;
+	const message = messages && messages[ 0 ];
+
+	return message && message.includes( 'required' );
+}
+
 module.exports = async ( req, res, next ) => {
 
 	const report = req.report;
@@ -74,6 +82,14 @@ module.exports = async ( req, res, next ) => {
 
 	} catch( e ){
 
-		next( e );
+		if( e.code === 'UNHANDLED_400' && isEuExitRequired( e.responseBody ) ){
+
+			res.render( 'reports/views/error/eu-exit-required' );
+
+		} else {
+
+			next( e );
+		}
+
 	}
 };

--- a/src/app/sub-apps/reports/views/error/eu-exit-required.njk
+++ b/src/app/sub-apps/reports/views/error/eu-exit-required.njk
@@ -1,0 +1,15 @@
+{% from 'app-components/heading.njk' import heading %}
+
+{% extends 'layout.njk' %}
+
+{% block page_title %}{{ super() }} - Add - Error submitting barrier{% endblock %}
+
+{% block page_content %}
+
+	<h1>Unable to submit barrier</h1>
+
+	<p class="restrict-width">
+		Since you started adding this barrier we have added a new question. <a href="{{ urls.reports.aboutProblem( report.id ) }}#eu-exit-related-1">Go to about the barrier</a> and answer if this barrier is EU exit related.
+	</p>
+
+{% endblock %}


### PR DESCRIPTION
If a user tries to submit an unfinished report that has not answered the EU exit question they will get an "Unexpected error", this adds a custom error code when the API returns a 400 and then a handler in the controller for that error code to show a custom error message.