### PR TITLE
Update typeahead limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "market-access-frontend",
-  "version": "6.4.2",
+  "version": "6.4.3",
   "description": "A front end for Market Access",
   "private": true,
   "main": "server.js",

--- a/src/public/js/vue/typeahead.vue
+++ b/src/public/js/vue/typeahead.vue
@@ -17,7 +17,7 @@
 			:internal-search="false"
 			:multiple="true"
 			:options="options"
-			:options-limit="500"
+			:options-limit="1000"
 			:showLabels="false"
 			:searchable="true"
 			:id="id"


### PR DESCRIPTION
Change Vue typeahead options limit from 500 to 1000 as you can't scroll all the options.
