### PR TITLE
Add barrier assessment

### DIFF
--- a/src/app/app.spec.js
+++ b/src/app/app.spec.js
@@ -1047,24 +1047,35 @@ describe( 'App', function(){
 					} );
 
 					describe( 'economic', () => {
-						it( 'Should render the page', ( done ) => {
+						describe( 'listing', () => {
+							it( 'Should render the page', ( done ) => {
 
-							app
-								.get( urls.barriers.assessment.economic( barrierId ) )
-								.end( checkPage( 'Market Access - Barrier Assessment - Economic assessment', done ) );
+								app
+									.get( urls.barriers.assessment.economic.list( barrierId ) )
+									.end( checkPage( 'Market Access - Barrier Assessment - Economic assessment', done ) );
+							} );
+
+							it( 'Should have the correct form action', ( done ) => {
+
+								const url = urls.barriers.assessment.economic.list( barrierId );
+								app
+									.get( url )
+									.end( ( err, res ) => {
+
+										const csrfToken = getCsrfTokenFromQueryParam( res, done.fail );
+
+										checkFormAction( `${ url }?_csrf=${ csrfToken }`, done )( err, res );
+									} );
+							} );
 						} );
 
-						it( 'Should have the correct form action', ( done ) => {
+						describe( 'new', () => {
+							it( 'Should redirect to the list page', ( done ) => {
 
-							const url = urls.barriers.assessment.economic( barrierId );
-							app
-								.get( url )
-								.end( ( err, res ) => {
-
-									const csrfToken = getCsrfTokenFromQueryParam( res, done.fail );
-
-									checkFormAction( `${ url }?_csrf=${ csrfToken }`, done )( err, res );
-								} );
+								app
+									.get( urls.barriers.assessment.economic.new( barrierId ) )
+									.end( checkRedirect( urls.barriers.assessment.economic.list( barrierId ), done ) );
+							} );
 						} );
 					} );
 
@@ -1136,7 +1147,7 @@ describe( 'App', function(){
 						} );
 					} );
 
-					describe( 'Barrier Documents', () => {
+					describe( 'Assessment Documents', () => {
 
 						let documentId;
 
@@ -1160,7 +1171,7 @@ describe( 'App', function(){
 								agent = supertest.agent( appInstance );
 
 								agent
-									.get( urls.barriers.assessment.economic( barrierId ) )
+									.get( urls.barriers.assessment.economic.list( barrierId ) )
 									.end( ( err, res ) => {
 
 										token = getCsrfTokenFromQueryParam( res, done.fail );
@@ -1183,7 +1194,7 @@ describe( 'App', function(){
 
 										agent.post( url )
 											.send( '' )
-											.end( checkRedirect( urls.barriers.assessment.economic( barrierId ), done ) );
+											.end( checkRedirect( urls.barriers.assessment.economic.list( barrierId ), done ) );
 									} );
 								} );
 
@@ -1216,7 +1227,7 @@ describe( 'App', function(){
 
 										agent.post( url )
 											.send( '' )
-											.end( checkRedirect( urls.barriers.assessment.economic( barrierId ), done ) );
+											.end( checkRedirect( urls.barriers.assessment.economic.list( barrierId ), done ) );
 									} );
 								} );
 

--- a/src/app/app.spec.js
+++ b/src/app/app.spec.js
@@ -80,6 +80,26 @@ function checkModal( done ){
 	};
 }
 
+function checkFormAction( url, done ){
+
+	return ( err, res ) => {
+
+		if( err ){ done.fail( err ); }
+
+		const matches = /<form.*action="(.+?)"/gm.exec( res.text );
+
+		if( matches ){
+
+			expect( matches[ 1 ] ).toEqual( url );
+			done();
+
+		} else {
+
+			done.fail();
+		}
+	};
+}
+
 function checkRedirect( location, done, responseCode = 302 ){
 
 	return ( err, res ) => {
@@ -1016,6 +1036,7 @@ describe( 'App', function(){
 							.get( `/barriers/${ barrierId }/assessment` )
 							.reply( 200, intercept.stub( '/backend/barriers/assessment') );
 					} );
+
 					describe( 'Detail', () => {
 						it( 'Should render the page', ( done ) => {
 
@@ -1031,6 +1052,82 @@ describe( 'App', function(){
 							app
 								.get( urls.barriers.assessment.economic( barrierId ) )
 								.end( checkPage( 'Market Access - Barrier Assessment - Economic assessment', done ) );
+						} );
+
+						it( 'Should have the correct form action', ( done ) => {
+
+							const url = urls.barriers.assessment.economic( barrierId );
+							app
+								.get( url )
+								.end( checkFormAction( url, done ) );
+						} );
+					} );
+
+					describe( 'economyValue', () => {
+						it( 'Should render the page', ( done ) => {
+
+							app
+								.get( urls.barriers.assessment.economyValue( barrierId ) )
+								.end( checkPage( 'Market Access - Barrier Assessment - UK economy value', done ) );
+						} );
+
+						it( 'Should have the correct form action', ( done ) => {
+
+							const url = urls.barriers.assessment.economyValue( barrierId );
+							app
+								.get( url )
+								.end( checkFormAction( url, done ) );
+						} );
+					} );
+
+					describe( 'marketSize', () => {
+						it( 'Should render the page', ( done ) => {
+
+							app
+								.get( urls.barriers.assessment.marketSize( barrierId ) )
+								.end( checkPage( 'Market Access - Barrier Assessment - Import market size', done ) );
+						} );
+
+						it( 'Should have the correct form action', ( done ) => {
+
+							const url = urls.barriers.assessment.marketSize( barrierId );
+							app
+								.get( url )
+								.end( checkFormAction( url, done ) );
+						} );
+					} );
+
+					describe( 'exportValue', () => {
+						it( 'Should render the page', ( done ) => {
+
+							app
+								.get( urls.barriers.assessment.exportValue( barrierId ) )
+								.end( checkPage( 'Market Access - Barrier Assessment - Affected UK exports', done ) );
+						} );
+
+						it( 'Should have the correct form action', ( done ) => {
+
+							const url = urls.barriers.assessment.exportValue( barrierId );
+							app
+								.get( url )
+								.end( checkFormAction( url, done ) );
+						} );
+					} );
+
+					describe( 'commercialValue', () => {
+						it( 'Should render the page', ( done ) => {
+
+							app
+								.get( urls.barriers.assessment.commercialValue( barrierId ) )
+								.end( checkPage( 'Market Access - Barrier Assessment - Commercial value', done ) );
+						} );
+
+						it( 'Should have the correct form action', ( done ) => {
+
+							const url = urls.barriers.assessment.commercialValue( barrierId );
+							app
+								.get( url )
+								.end( checkFormAction( url, done ) );
 						} );
 					} );
 				} );

--- a/src/app/app.spec.js
+++ b/src/app/app.spec.js
@@ -1006,6 +1006,32 @@ describe( 'App', function(){
 								} );
 							} );
 						} );
+					} ) ;
+				} );
+
+				describe( 'Barrier assessment', () => {
+
+					beforeEach( () => {
+						intercept.backend()
+							.get( `/barriers/${ barrierId }/assessment` )
+							.reply( 200, intercept.stub( '/backend/barriers/assessment') );
+					} );
+					describe( 'Detail', () => {
+						it( 'Should render the page', ( done ) => {
+
+							app
+								.get( urls.barriers.assessment.detail( barrierId ) )
+								.end( checkPage( 'Market Access - Barrier Assessment', done ) );
+						} );
+					} );
+
+					describe( 'economic', () => {
+						it( 'Should render the page', ( done ) => {
+
+							app
+								.get( urls.barriers.assessment.economic( barrierId ) )
+								.end( checkPage( 'Market Access - Barrier Assessment - Economic assessment', done ) );
+						} );
 					} );
 				} );
 			} );

--- a/src/app/app.spec.js
+++ b/src/app/app.spec.js
@@ -1059,7 +1059,12 @@ describe( 'App', function(){
 							const url = urls.barriers.assessment.economic( barrierId );
 							app
 								.get( url )
-								.end( checkFormAction( url, done ) );
+								.end( ( err, res ) => {
+
+									const csrfToken = getCsrfTokenFromQueryParam( res, done.fail );
+
+									checkFormAction( `${ url }?_csrf=${ csrfToken }`, done )( err, res );
+								} );
 						} );
 					} );
 

--- a/src/app/lib/Form.js
+++ b/src/app/lib/Form.js
@@ -61,6 +61,17 @@ function Form( req, fields ){
 	this.values = {};
 	this.errors = [];
 
+	function getValue( field, name ){
+
+		const value = req.body[ name ];
+
+		if( field.sanitize ){
+			return field.sanitize( value );
+		}
+
+		return value;
+	}
+
 	for( let [ name, field ] of Object.entries( fields ) ){
 
 		this.addField( name, field );
@@ -79,7 +90,7 @@ function Form( req, fields ){
 
 			} else {
 
-				this.values[ name ] = req.body[ name ];
+				this.values[ name ] = getValue( field, name );
 			}
 		}
 	}

--- a/src/app/lib/Form.spec.js
+++ b/src/app/lib/Form.spec.js
@@ -42,7 +42,7 @@ describe( 'Form', () => {
 
 				req.body = {
 					test: 'value-1',
-					another: 'another-1',
+					sanitize: '1,000,000',
 					unknown: 'unknown-1',
 					item1: 'checkbox-value-1',
 					item2: 'checkbox-value-2',
@@ -80,9 +80,10 @@ describe( 'Form', () => {
 						required: 'Test required message',
 						errorField: 'c'
 					},
-					another: {
+					sanitize: {
 						values: [ 'another-2' ],
-						required: 'Test another required message'
+						required: 'Test a sanitized value required message',
+						sanitize: ( value ) => value.replace( /,/g, '' ),
 					}
 				};
 			} );
@@ -99,7 +100,7 @@ describe( 'Form', () => {
 				} );
 			} );
 
-			it( 'Should put the field names in an internal array and the body values in an internal array', () => {
+			it( 'Should put the field names in an internal array and the sanitized body values in an internal array', () => {
 
 				const keys = Object.keys( fields );
 
@@ -125,6 +126,10 @@ describe( 'Form', () => {
 							groupItem2: req.body.groupItem2
 						} );
 
+					} else if( name === 'sanitize' ){
+
+						expect( form.values[ name ] ).toEqual( '1000000' );
+
 					} else {
 
 						expect( form.values[ name ] ).toEqual( req.body[ name ] );
@@ -145,7 +150,7 @@ describe( 'Form', () => {
 							item2: 'checkbox-value-2'
 						},
 						test: 'value-1',
-						another: 'another-1'
+						sanitize: '1000000'
 					} );
 				} );
 			} );

--- a/src/app/lib/backend-service.js
+++ b/src/app/lib/backend-service.js
@@ -423,7 +423,7 @@ module.exports = {
 				saveEconomic: ( req, barrier, values ) => saveAssessmentValues( req, barrier, {
 					impact: values.impact,
 					explanation: values.description,
-					//documents: []
+					documents: ( values.documentIds ? values.documentIds : null ),
 				} ),
 				saveEconomyValue: ( req, barrier, value ) => saveAssessmentValues( req, barrier,  {
 					value_to_economy: value,

--- a/src/app/lib/backend-service.js
+++ b/src/app/lib/backend-service.js
@@ -407,6 +407,31 @@ module.exports = {
 				role: values.role,
 			} ),
 			delete: ( req, barrierMemberId ) => backend.delete( `/barriers/members/${ barrierMemberId }`, getToken( req ) ),
+		},
+		assessment: {
+			get: ( req, barrierId ) => backend.get( `/barriers/${ barrierId }/assessment`, getToken( req ) ),
+			create: ( req, barrierId, values ) => backend.post( `/barriers/${ barrierId }/assessment`, getToken( req ), {
+				impact: values.impact,
+				explanation: values.description,
+				//documents: []
+			} ),
+			update: ( req, barrierId, values ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
+				impact: values.impact,
+				explanation: values.description,
+				//documents: []
+			} ),
+			saveEconomyValue: ( req, barrierId, value ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
+				value_to_economy: value,
+			} ),
+			saveMarketSize: ( req, barrierId, value ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
+				import_market_size: value,
+			} ),
+			saveExportValue: ( req, barrierId, value ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
+				export_value: value,
+			} ),
+			saveCommercialValue: ( req, barrierId, value ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
+				commercial_value: value,
+			} ),
 		}
 	},
 

--- a/src/app/lib/backend-service.js
+++ b/src/app/lib/backend-service.js
@@ -408,31 +408,37 @@ module.exports = {
 			} ),
 			delete: ( req, barrierMemberId ) => backend.delete( `/barriers/members/${ barrierMemberId }`, getToken( req ) ),
 		},
-		assessment: {
-			get: ( req, barrierId ) => backend.get( `/barriers/${ barrierId }/assessment`, getToken( req ) ),
-			create: ( req, barrierId, values ) => backend.post( `/barriers/${ barrierId }/assessment`, getToken( req ), {
-				impact: values.impact,
-				explanation: values.description,
-				//documents: []
-			} ),
-			update: ( req, barrierId, values ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
-				impact: values.impact,
-				explanation: values.description,
-				//documents: []
-			} ),
-			saveEconomyValue: ( req, barrierId, value ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
-				value_to_economy: value,
-			} ),
-			saveMarketSize: ( req, barrierId, value ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
-				import_market_size: value,
-			} ),
-			saveExportValue: ( req, barrierId, value ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
-				export_value: value,
-			} ),
-			saveCommercialValue: ( req, barrierId, value ) => backend.patch( `/barriers/${ barrierId }/assessment`, getToken( req ), {
-				commercial_value: value,
-			} ),
-		}
+		assessment: (() => {
+
+			function saveAssessmentValues( req, barrier, values ){
+
+				const isPatch = barrier.has_assessment;
+				const url = `/barriers/${ barrier.id }/assessment`;
+
+				return backend[ ( isPatch ? 'patch' : 'post' ) ]( url, getToken( req ), values );
+			}
+
+			return {
+				get: ( req, barrierId ) => backend.get( `/barriers/${ barrierId }/assessment`, getToken( req ) ),
+				saveEconomic: ( req, barrier, values ) => saveAssessmentValues( req, barrier, {
+					impact: values.impact,
+					explanation: values.description,
+					//documents: []
+				} ),
+				saveEconomyValue: ( req, barrier, value ) => saveAssessmentValues( req, barrier,  {
+					value_to_economy: value,
+				} ),
+				saveMarketSize: ( req, barrier, value ) => saveAssessmentValues( req, barrier,  {
+					import_market_size: value,
+				} ),
+				saveExportValue: ( req, barrier, value ) => saveAssessmentValues( req, barrier,  {
+					export_value: value,
+				} ),
+				saveCommercialValue: ( req, barrier, value ) => saveAssessmentValues( req, barrier,  {
+					commercial_value: value,
+				} ),
+			};
+		})(),
 	},
 
 	reports: {

--- a/src/app/lib/backend-service.js
+++ b/src/app/lib/backend-service.js
@@ -420,6 +420,7 @@ module.exports = {
 
 			return {
 				get: ( req, barrierId ) => backend.get( `/barriers/${ barrierId }/assessment`, getToken( req ) ),
+				getHistory: ( req, barrierId ) => backend.get( `/barriers/${ barrierId }/assessment_history`, getToken( req ) ),
 				saveEconomic: ( req, barrier, values ) => saveAssessmentValues( req, barrier, {
 					impact: values.impact,
 					explanation: values.description,

--- a/src/app/lib/backend-service.spec.js
+++ b/src/app/lib/backend-service.spec.js
@@ -1159,6 +1159,29 @@ describe( 'Backend Service', () => {
 		} );
 
 		describe( 'assessment', () => {
+
+			beforeEach( () => {
+				req.barrier = {
+					id: barrierId,
+					has_assessment: false,
+				};
+			} );
+
+			async function checkPostAndPatch( method, inputValues, outputValues ){
+
+				const url = `/barriers/${ barrierId }/assessment`;
+
+				await method( req, req.barrier, inputValues );
+
+				expect( backend.post ).toHaveBeenCalledWith( url, token, outputValues );
+
+				req.barrier.has_assessment = true;
+
+				await method( req, req.barrier, inputValues );
+
+				expect( backend.patch ).toHaveBeenCalledWith( url, token, outputValues );
+			}
+
 			describe( 'get', () => {
 				it( 'Should GET the correct path', async () => {
 
@@ -1168,7 +1191,7 @@ describe( 'Backend Service', () => {
 				} );
 			} );
 
-			describe( 'create', () => {
+			describe( 'saveEconomic', () => {
 				it( 'Should POST to the correct path with the correct values', async () => {
 
 					const values = {
@@ -1176,28 +1199,53 @@ describe( 'Backend Service', () => {
 						description: faker.lorem.paragraph( 2 ),
 					};
 
-					await service.barriers.assessment.create( req, barrierId, values );
-
-					expect( backend.post ).toHaveBeenCalledWith( `/barriers/${ barrierId }/assessment`, token, {
+					await checkPostAndPatch( service.barriers.assessment.saveEconomic, values, {
 						impact: values.impact,
 						explanation: values.description,
 					} );
 				} );
 			} );
 
-			describe( 'update', () => {
+			describe( 'saveEconomyValue', () => {
 				it( 'Should POST to the correct path with the correct values', async () => {
 
-					const values = {
-						impact: faker.lorem.word().toUpperCase(),
-						description: faker.lorem.paragraph( 2 ),
-					};
+					const value = faker.random.number();
 
-					await service.barriers.assessment.update( req, barrierId, values );
+					await checkPostAndPatch( service.barriers.assessment.saveEconomyValue, value, {
+						value_to_economy: value,
+					} );
+				} );
+			} );
 
-					expect( backend.patch ).toHaveBeenCalledWith( `/barriers/${ barrierId }/assessment`, token, {
-						impact: values.impact,
-						explanation: values.description,
+			describe( 'saveMarketSize', () => {
+				it( 'Should POST to the correct path with the correct values', async () => {
+
+					const value = faker.random.number();
+
+					await checkPostAndPatch( service.barriers.assessment.saveMarketSize, value, {
+						import_market_size: value,
+					} );
+				} );
+			} );
+
+			describe( 'saveExportValue', () => {
+				it( 'Should POST to the correct path with the correct values', async () => {
+
+					const value = faker.random.number();
+
+					await checkPostAndPatch( service.barriers.assessment.saveExportValue, value, {
+						export_value: value,
+					} );
+				} );
+			} );
+
+			describe( 'saveCommercialValue', () => {
+				it( 'Should POST to the correct path with the correct values', async () => {
+
+					const value = faker.random.number();
+
+					await checkPostAndPatch( service.barriers.assessment.saveCommercialValue, value, {
+						commercial_value: value,
 					} );
 				} );
 			} );

--- a/src/app/lib/backend-service.spec.js
+++ b/src/app/lib/backend-service.spec.js
@@ -1191,6 +1191,15 @@ describe( 'Backend Service', () => {
 				} );
 			} );
 
+			describe( 'getHistory', () => {
+				it( 'Should GET the correct path', async () => {
+
+					await service.barriers.assessment.getHistory( req, barrierId );
+
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers/${ barrierId }/assessment_history`, token );
+				} );
+			} );
+
 			describe( 'saveEconomic', () => {
 				describe( 'Without any documentIds', () => {
 					it( 'Should POST to the correct path with the correct values', async () => {

--- a/src/app/lib/backend-service.spec.js
+++ b/src/app/lib/backend-service.spec.js
@@ -1157,6 +1157,51 @@ describe( 'Backend Service', () => {
 				} );
 			} );
 		} );
+
+		describe( 'assessment', () => {
+			describe( 'get', () => {
+				it( 'Should GET the correct path', async () => {
+
+					await service.barriers.assessment.get( req, barrierId );
+
+					expect( backend.get ).toHaveBeenCalledWith( `/barriers/${ barrierId }/assessment`, token );
+				} );
+			} );
+
+			describe( 'create', () => {
+				it( 'Should POST to the correct path with the correct values', async () => {
+
+					const values = {
+						impact: faker.lorem.word().toUpperCase(),
+						description: faker.lorem.paragraph( 2 ),
+					};
+
+					await service.barriers.assessment.create( req, barrierId, values );
+
+					expect( backend.post ).toHaveBeenCalledWith( `/barriers/${ barrierId }/assessment`, token, {
+						impact: values.impact,
+						explanation: values.description,
+					} );
+				} );
+			} );
+
+			describe( 'update', () => {
+				it( 'Should POST to the correct path with the correct values', async () => {
+
+					const values = {
+						impact: faker.lorem.word().toUpperCase(),
+						description: faker.lorem.paragraph( 2 ),
+					};
+
+					await service.barriers.assessment.update( req, barrierId, values );
+
+					expect( backend.patch ).toHaveBeenCalledWith( `/barriers/${ barrierId }/assessment`, token, {
+						impact: values.impact,
+						explanation: values.description,
+					} );
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'Reports', () => {

--- a/src/app/lib/backend-service.spec.js
+++ b/src/app/lib/backend-service.spec.js
@@ -1192,16 +1192,36 @@ describe( 'Backend Service', () => {
 			} );
 
 			describe( 'saveEconomic', () => {
-				it( 'Should POST to the correct path with the correct values', async () => {
+				describe( 'Without any documentIds', () => {
+					it( 'Should POST to the correct path with the correct values', async () => {
 
-					const values = {
-						impact: faker.lorem.word().toUpperCase(),
-						description: faker.lorem.paragraph( 2 ),
-					};
+						const values = {
+							impact: faker.lorem.word().toUpperCase(),
+							description: faker.lorem.paragraph( 2 ),
+						};
 
-					await checkPostAndPatch( service.barriers.assessment.saveEconomic, values, {
-						impact: values.impact,
-						explanation: values.description,
+						await checkPostAndPatch( service.barriers.assessment.saveEconomic, values, {
+							impact: values.impact,
+							explanation: values.description,
+							documents: null,
+						} );
+					} );
+				} );
+
+				describe( 'With documentIds', () => {
+					it( 'Should POST to the correct path with the correct values', async () => {
+
+						const values = {
+							impact: faker.lorem.word().toUpperCase(),
+							description: faker.lorem.paragraph( 2 ),
+							documentIds: [ uuid(), uuid() ],
+						};
+
+						await checkPostAndPatch( service.barriers.assessment.saveEconomic, values, {
+							impact: values.impact,
+							explanation: values.description,
+							documents: values.documentIds,
+						} );
 					} );
 				} );
 			} );

--- a/src/app/lib/document-controllers.js
+++ b/src/app/lib/document-controllers.js
@@ -1,0 +1,179 @@
+const config = require( '../config' );
+const metadata = require( './metadata' );
+const fileSize = require( './file-size' );
+const reporter = require( './reporter' );
+const validators = require( './validators' );
+const uploadDocument = require( './upload-document' );
+const backend = require( './backend-service' );
+const HttpResponseError = require( './HttpResponseError' );
+
+const MAX_FILE_SIZE = fileSize( config.files.maxSize );
+const OVERSIZE_FILE_MESSAGE = `File size exceeds the ${ MAX_FILE_SIZE } limit. Reduce file size and upload the document again.`;
+const INVALID_FILE_TYPE_MESSAGE = `Unsupported file format. The following file formats are accepted ${ getValidTypes() }`;
+const UPLOAD_ERROR_MESSAGE = 'A system error has occured, so the file has not been uploaded. Try again.';
+const DELETE_ERROR_MESSAGE = 'A system error has occured, so the file has not been deleted. Try again.';
+const FILE_INFECTED_MESSAGE = 'This file may be infected with a virus and will not be accepted.';
+
+function getValidTypes(){
+
+	const types = [];
+
+	config.files.types.forEach( ( type ) => {
+
+		const file = metadata.mimeTypes[ type ];
+
+		if( file ){ types.push( file ); return; }
+
+		reporter.message( 'info', 'No file extension mapping found for valid type: ' + type );
+
+		types.push( type );
+	} );
+
+	return types.join( ', ' );
+}
+
+function reportInvalidFile( file = {} ){
+	reporter.message( 'info', 'Invalid document type: ' + file.type, { size: file.size, name: file.name } );
+}
+
+module.exports = {
+
+	MAX_FILE_SIZE,
+	OVERSIZE_FILE_MESSAGE,
+	INVALID_FILE_TYPE_MESSAGE,
+	UPLOAD_ERROR_MESSAGE,
+	FILE_INFECTED_MESSAGE,
+
+	reportInvalidFile,
+
+	xhr: {
+		add: ( passedCb ) => async ( req, res ) => {
+
+			const document = req.body.document;
+
+			if( req.formError ){
+
+				const isOverSize = validators.isFileOverSize( req.formError );
+
+				res.status( 400 );
+				res.json( { message: ( isOverSize ? OVERSIZE_FILE_MESSAGE : UPLOAD_ERROR_MESSAGE ) } );
+
+				if( !isOverSize ){
+
+					reporter.captureException( req.formError );
+				}
+
+			} else if( document && validators.isValidFile( document ) ){
+
+				try {
+
+					const documentId = await uploadDocument( req, document );
+					const { passed } = await backend.documents.getScanStatus( req, documentId );
+
+					if( passed ){
+
+						passedCb( req, {
+							id: documentId,
+							size: fileSize( document.size ),
+							name: document.name,
+						} );
+
+						res.json( {
+							documentId,
+							file: { name: document.name, size: fileSize( document.size ) },
+						} );
+
+					} else {
+
+						res.status( 401 );
+						res.json( { message: FILE_INFECTED_MESSAGE } );
+					}
+
+				} catch( e ){
+
+					res.status( 500 );
+					res.json( { message: UPLOAD_ERROR_MESSAGE } );
+					reporter.captureException( e );
+				}
+
+			} else {
+
+				res.status( 400 );
+				res.json( { message: INVALID_FILE_TYPE_MESSAGE } );
+				reportInvalidFile( document );
+			}
+		},
+
+		delete: ( getDocumentId, successCb ) => async ( req, res ) => {
+
+			const documentId = getDocumentId( req );
+
+			try {
+
+				if( !validators.isUuid( documentId ) ){ throw new Error( 'Invalid documentId' ); }
+
+				const { response, body } = await backend.documents.delete( req, documentId );
+
+				if( response.isSuccess || response.statusCode === 404 ){
+
+					successCb( req, documentId );
+					res.status( 200 );
+					res.json( {} );
+
+				} else {
+
+					throw new HttpResponseError( `Unable to delete document ${ documentId }`, response, body );
+				}
+
+			} catch ( e ){
+
+				res.status( 500 );
+				res.json( { message: DELETE_ERROR_MESSAGE } );
+				reporter.captureException( e );
+			}
+		},
+	},
+
+	delete: ( getDocumentId, getRedirectUrl, successCb ) => async ( req, res, next ) => {
+
+		const documentId = getDocumentId( req );
+
+		try {
+
+			if( !validators.isUuid( documentId ) ){ throw new Error( 'Invalid documentId' ); }
+
+			const { response, body } = await backend.documents.delete( req, documentId );
+
+			if( response.isSuccess || response.statusCode === 400 ){
+
+				successCb( req, documentId );
+
+				if( req.xhr ){
+
+					res.json( {} );
+
+				} else {
+
+					res.redirect( getRedirectUrl( req ) );
+				}
+
+			} else {
+
+				throw new HttpResponseError( `Unable to delete document ${ documentId }`, response, body );
+			}
+
+		} catch ( e ){
+
+			if( req.xhr ){
+
+				res.status( 500 );
+				res.json( { message: DELETE_ERROR_MESSAGE } );
+				reporter.captureException( e );
+
+			} else {
+
+				next( e );
+			}
+		}
+	}
+};

--- a/src/app/lib/document-controllers.js
+++ b/src/app/lib/document-controllers.js
@@ -146,6 +146,11 @@ module.exports = {
 
 			if( response.isSuccess || response.statusCode === 400 ){
 
+				// A 400 in this case means that the document is attached to something, therefore we treat this as a success
+				// This means that we can call the successCb (which whould remove the document from the session)
+				// Then when the form with the document is actually saved (e.g. a note) we pass the correct list of documents from the session
+				// The backend will then delete any documents and/or add new ones
+
 				successCb( req, documentId );
 
 				if( req.xhr ){

--- a/src/app/lib/document-controllers.spec.js
+++ b/src/app/lib/document-controllers.spec.js
@@ -1,0 +1,467 @@
+const proxyquire = require( 'proxyquire' );
+const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( './HttpResponseError' );
+const modulePath = './document-controllers';
+
+const { mocks } = jasmine.helpers;
+const DELETE_ERROR_MESSAGE = 'A system error has occured, so the file has not been deleted. Try again.';
+
+describe( 'document controllers', () => {
+
+	let controllers;
+	let config;
+	let reporter;
+	let validators;
+	let uploadDocument;
+	let backend;
+
+	beforeEach( () => {
+
+		config = {
+			files: {
+				maxSize: ( 5 * 1024 * 1024 ),
+				types: [ 'image/jpeg', 'text/csv' ]
+			}
+		};
+
+		reporter = mocks.reporter();
+
+		validators = {
+			isValidFile: jasmine.createSpy( 'validators.isValidFile' ),
+			isUuid: jasmine.createSpy( 'validators.isUuid' ),
+		};
+
+		uploadDocument = jasmine.createSpy( 'uploadDocument' );
+
+		backend = {
+			documents: {
+				getScanStatus: jasmine.createSpy( 'backend.documents.getScanStatus' ),
+				delete: jasmine.createSpy( 'backend.documents.delete' ),
+			},
+		};
+	} );
+
+	describe( 'With a missing mime type map', () => {
+		it( 'Should report the error', () => {
+
+			config.files.types.push( 'fake/mime' );
+
+			proxyquire( modulePath, {
+				'../config': config,
+				'./reporter': reporter,
+				'./validators': validators,
+				'./upload-document': uploadDocument,
+				'./backend-service': backend,
+			} );
+
+			expect( reporter.message ).toHaveBeenCalledWith( 'info', 'No file extension mapping found for valid type: fake/mime'  );
+		} );
+	} );
+
+	describe( 'Without missing mime types', () => {
+
+		let req;
+		let res;
+		let next;
+
+		beforeEach( () => {
+
+			({ req, res, next } = mocks.middleware());
+
+			controllers = proxyquire( modulePath, {
+				'../config': config,
+				'./reporter': reporter,
+				'./validators': validators,
+				'./upload-document': uploadDocument,
+				'./backend-service': backend,
+			} );
+		} );
+
+		it( 'Does not report any missing mappings', () => {
+
+			expect( reporter.message ).not.toHaveBeenCalled();
+		} );
+
+		describe( 'constants', () => {
+			it( 'Defines them correctly', () => {
+
+				expect( controllers.MAX_FILE_SIZE ).toBeDefined();
+				expect( controllers.OVERSIZE_FILE_MESSAGE ).toBeDefined();
+				expect( controllers.INVALID_FILE_TYPE_MESSAGE ).toBeDefined();
+				expect( controllers.UPLOAD_ERROR_MESSAGE ).toBeDefined();
+				expect( controllers.FILE_INFECTED_MESSAGE ).toBeDefined();
+			} );
+		} );
+
+		describe( 'reportInvalidFile', () => {
+			it( 'Reports a file to the reporter', () => {
+
+				const file = { type: 'text/plain', size: 100, name: 'text-doc.txt' };
+
+				controllers.reportInvalidFile( file );
+
+				expect( reporter.message ).toHaveBeenCalledWith( 'info', 'Invalid document type: ' + file.type, { size: file.size, name: file.name } );
+			} );
+		} );
+
+		describe( 'controllers', () => {
+
+			let documentId;
+
+			beforeEach( () => {
+
+				documentId = uuid();
+			} );
+
+			describe( 'xhr', () => {
+				describe( '#add', () => {
+
+					let controller;
+					let passedCb;
+
+					beforeEach( () => {
+
+						passedCb = jasmine.createSpy( 'passedCb' );
+						controller = controllers.xhr.add( passedCb );
+					} );
+
+					describe( 'When there is a formError on the req', () => {
+						describe( 'When the error is about file size', () => {
+							it( 'Should return a 400 with a message', async () => {
+
+								req.formError = new Error( 'The error is maxFileSize exceeded' );
+
+								await controller( req, res );
+
+								expect( res.status ).toHaveBeenCalledWith( 400 );
+								expect( res.json ).toHaveBeenCalledWith( { message: 'File size exceeds the 5 MB limit. Reduce file size and upload the document again.' } );
+								expect( reporter.message ).not.toHaveBeenCalled();
+								expect( reporter.captureException ).not.toHaveBeenCalled();
+							} );
+						} );
+
+						describe( 'When the error is about something else', () => {
+							it( 'Should return a 400 with a message', async () => {
+
+								req.formError = new Error( 'The error is something else' );
+
+								await controller( req, res );
+
+								expect( res.status ).toHaveBeenCalledWith( 400 );
+								expect( res.json ).toHaveBeenCalledWith( { message: 'A system error has occured, so the file has not been uploaded. Try again.' } );
+								expect( reporter.captureException ).toHaveBeenCalledWith( req.formError );
+							} );
+						} );
+					} );
+
+					describe( 'When there is not a formError', () => {
+						describe( 'When there is not a document', () => {
+							it( 'Should return a 400 with an error message', async () => {
+
+								await controller( req, res );
+
+								expect( res.status ).toHaveBeenCalledWith( 400 );
+								expect( res.json ).toHaveBeenCalledWith( { message: 'Unsupported file format. The following file formats are accepted .jpg, .csv' } );
+								expect( reporter.message ).toHaveBeenCalledWith( 'info', 'Invalid document type: undefined', { size: undefined, name: undefined } );
+							} );
+						} );
+
+						describe( 'When there is a document', () => {
+
+							let doc;
+
+							beforeEach( () => {
+
+								doc = { type: 'text/plain', size: 10, name: 'test-1.txt' };
+								req.body.document = doc;
+							} );
+
+							describe( 'When the document is invalid', () => {
+								it( 'Should return 400 with an error message', async () => {
+
+									validators.isValidFile.and.callFake( () => false );
+
+									await controller( req, res );
+
+									expect( res.status ).toHaveBeenCalledWith( 400 );
+									expect( res.json ).toHaveBeenCalledWith( { message: 'Unsupported file format. The following file formats are accepted .jpg, .csv' } );
+									expect( reporter.message ).toHaveBeenCalledWith( 'info', `Invalid document type: ${ doc.type }`, { size: doc.size, name: doc.name } );
+								} );
+							} );
+
+							describe( 'When the document is valid', () => {
+
+								beforeEach( () => {
+
+									validators.isValidFile.and.callFake( () => true );
+								} );
+
+								describe( 'When uploadDocument returns an error', () => {
+									it( 'Should return a 500', async () => {
+
+										const err = new Error( 'uploadDocument error' );
+
+										uploadDocument.and.callFake( () => Promise.reject( err ) );
+
+										await controller( req, res );
+
+										expect( res.status ).toHaveBeenCalledWith( 500 );
+										expect( res.json ).toHaveBeenCalledWith( { message: 'A system error has occured, so the file has not been uploaded. Try again.' } );
+										expect( reporter.captureException ).toHaveBeenCalledWith( err );
+									} );
+								} );
+
+								describe( 'When uploadDocument returns a documentId', () => {
+
+									let documentId;
+
+									beforeEach( () => {
+
+										documentId = uuid();
+										uploadDocument.and.callFake( () => documentId );
+									} );
+
+									describe( 'When the document does not pass virus scanning', () => {
+										it( 'Should return a 401', async () => {
+
+											backend.documents.getScanStatus.and.callFake( () => Promise.resolve( { passed: false } ) );
+
+											await controller( req, res );
+
+											expect( res.status ).toHaveBeenCalledWith( 401 );
+											expect( res.json ).toHaveBeenCalledWith( { message: 'This file may be infected with a virus and will not be accepted.' } );
+										} );
+									} );
+
+									describe( 'When the document passes virus scanning', () => {
+										it( 'Should return the document details and add the document to the session', async () => {
+
+											backend.documents.getScanStatus.and.callFake( () => Promise.resolve( { passed: true } ) );
+
+											await controller( req, res );
+
+											expect( res.json ).toHaveBeenCalledWith( {
+												documentId,
+												file: { name: doc.name, size: '10 Bytes' }
+											} );
+
+											passedCb( documentId, doc );
+										} );
+									} );
+								} );
+							} );
+						} );
+					} );
+				} );
+
+				describe( '#delete', () => {
+
+					let successCb;
+					let getDocumentId;
+
+					beforeEach( () => {
+
+						successCb = jasmine.createSpy( 'successCb' );
+						getDocumentId = jasmine.createSpy( 'getDocumentId' ).and.returnValue( documentId );
+					} );
+
+					describe( 'When the uuid is invalid', () => {
+						it( 'Throws an error', () => {
+
+							validators.isUuid.and.returnValue( false );
+
+							controllers.xhr.delete( getDocumentId, successCb )( req, res );
+
+							expect( successCb ).not.toHaveBeenCalled();
+							expect( res.status ).toHaveBeenCalledWith( 500 );
+							expect( res.json ).toHaveBeenCalledWith( { message: DELETE_ERROR_MESSAGE } );
+							expect( reporter.captureException ).toHaveBeenCalledWith( new Error( 'Invalid documentId' ) );
+						} );
+					} );
+
+					describe( 'When the uuid is valid', () => {
+
+						let controller;
+
+						beforeEach( () => {
+
+							validators.isUuid.and.returnValue( true );
+							controller = controllers.xhr.delete( getDocumentId, successCb );
+						} );
+
+						afterEach( () => {
+
+							expect( backend.documents.delete ).toHaveBeenCalledWith( req, documentId );
+						} );
+
+						describe( 'When the backend returns an error', () => {
+							it( 'Should return a JSON error with status 500', async () => {
+
+								const err = new Error( 'A backend error' );
+								backend.documents.delete.and.callFake( () => Promise.reject( err ) );
+
+								await controller( req, res );
+
+								expect( res.status ).toHaveBeenCalledWith( 500 );
+								expect( res.json ).toHaveBeenCalledWith( { message: DELETE_ERROR_MESSAGE } );
+								expect( reporter.captureException ).toHaveBeenCalledWith( err );
+								expect( successCb ).not.toHaveBeenCalled();
+							} );
+						} );
+
+						describe( 'When the backend returns a 200', () => {
+							describe( 'When there are not any documents in the session', () => {
+								it( 'Should return the response in JSON', async () => {
+
+									backend.documents.delete.and.callFake( () => Promise.resolve( {
+										response: { isSuccess: true }
+									} ) );
+
+									await controller( req, res );
+
+									expect( res.json ).toHaveBeenCalledWith( {} );
+									expect( successCb ).toHaveBeenCalledWith( req, documentId );
+								} );
+							} );
+						} );
+
+						describe( 'When the backend returns a 500', () => {
+							describe( 'When there are not any documents in the session', () => {
+								it( 'Should return a 500 and report the error in JSON', async () => {
+
+									backend.documents.delete.and.callFake( () => Promise.resolve( {
+										response: { isSuccess: false, statusCode: 500 }
+									} ) );
+
+									await controller( req, res );
+
+									expect( res.status ).toHaveBeenCalledWith( 500 );
+									expect( res.json ).toHaveBeenCalledWith( { message: DELETE_ERROR_MESSAGE } );
+									expect( reporter.captureException ).toHaveBeenCalled();
+									expect( reporter.captureException.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
+								} );
+							} );
+						} );
+					} );
+				} );
+			} );
+
+			describe( '#delete', () => {
+
+				let successCb;
+				let getDocumentId;
+				let getRedirectUrl;
+				let controller;
+
+				beforeEach( () => {
+
+					successCb = jasmine.createSpy( 'successCb' );
+					getDocumentId = jasmine.createSpy( 'getDocumentId' ).and.returnValue( documentId );
+					getRedirectUrl = jasmine.createSpy( 'getRedirectUrl' );
+
+					controller = controllers.delete( getDocumentId, getRedirectUrl, successCb );
+				} );
+
+				describe( 'When the document id is invalid', () => {
+
+					beforeEach( () => {
+
+						validators.isUuid.and.callFake( () => false );
+					} );
+
+					describe( 'A normal request', () => {
+						it( 'Calls next with an error', async () => {
+
+							await controller( req, res, next );
+
+							expect( next ).toHaveBeenCalledWith( new Error( 'Invalid documentId' ) );
+						} );
+					} );
+
+					describe( 'An XHR request', () => {
+						it( 'Should return a 500 and report the error', async () => {
+
+							req.xhr = true;
+
+							await controller( req, res, next );
+
+							expect( res.status ).toHaveBeenCalledWith( 500 );
+							expect( res.json ).toHaveBeenCalledWith( { message: DELETE_ERROR_MESSAGE } );
+							expect( reporter.captureException ).toHaveBeenCalledWith( new Error( 'Invalid documentId' ) );
+						} );
+					} );
+				} );
+
+				describe( 'When the document id is valid', () => {
+
+					beforeEach( () => {
+
+						validators.isUuid.and.callFake( () => true );
+						req.xhr = true;
+					} );
+
+					describe( 'When the backend delete rejects', () => {
+						it( 'Should return a 500 with the correct message', async () => {
+
+							const err = new Error( 'A backend fail' );
+
+							backend.documents.delete.and.callFake( () => Promise.reject( err ) );
+
+							await controller( req, res, next );
+
+							expect( res.status ).toHaveBeenCalledWith( 500 );
+							expect( res.json ).toHaveBeenCalledWith( { message: DELETE_ERROR_MESSAGE } );
+							expect( reporter.captureException ).toHaveBeenCalledWith( err );
+						} );
+					} );
+
+					describe( 'When the backend resolves', () => {
+
+						beforeEach( () => {
+
+							req.xhr = true;
+						} );
+
+						describe( 'When it is a 500', () => {
+							it( 'Should report the error', async() => {
+
+								backend.documents.delete.and.callFake( () => Promise.resolve( { response: { statusCode: 500 } } ) );
+
+								await controller( req, res, next );
+
+								expect( res.status ).toHaveBeenCalledWith( 500 );
+								expect( res.json ).toHaveBeenCalledWith( { message: 'A system error has occured, so the file has not been deleted. Try again.' } );
+								expect( reporter.captureException ).toHaveBeenCalled();
+								expect( reporter.captureException.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
+							} );
+						} );
+
+						describe( 'When it is a 200', () => {
+							it( 'Calls the successCb', async () => {
+
+								backend.documents.delete.and.callFake( () => Promise.resolve( { response: { isSuccess: true } } ) );
+
+								await controller( req, res, next );
+
+								expect( res.json ).toHaveBeenCalledWith( {} );
+								expect( successCb ).toHaveBeenCalledWith( req, documentId );
+							} );
+						} );
+
+						describe( 'When it is a 400', () => {
+							it( 'Calls the successCb', async () => {
+
+								backend.documents.delete.and.callFake( () => Promise.resolve( { response: { statusCode: 400 } } ) );
+
+								await controller( req, res, next );
+
+								expect( res.json ).toHaveBeenCalledWith( {} );
+								expect( successCb ).toHaveBeenCalledWith( req, documentId );
+							} );
+						} );
+					} );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/src/app/lib/metadata.js
+++ b/src/app/lib/metadata.js
@@ -244,6 +244,7 @@ module.exports.fetch = async () => {
 			}
 
 			module.exports.barrierPendingOptions = body.barrier_pending;
+			module.exports.barrierAssessmentImpactOptions = body.assessment_impact;
 
 		} else {
 

--- a/src/app/lib/metadata.js
+++ b/src/app/lib/metadata.js
@@ -313,6 +313,15 @@ module.exports.barrier = {
 			'2': 'My team barriers',
 		}
 	},
+	assessment: {
+		fieldNames: {
+			impact: 'Economic assessment',
+			value_to_economy: 'Value to UK Economy',
+			import_market_size: 'Import Market Size',
+			export_value: 'Value of currently affected UK exports',
+			commercial_value: 'Commercial Value'
+		}
+	}
 };
 
 module.exports.getBarrierCreatedBy = ( id ) => module.exports.barrier.createdBy.items[ id ];

--- a/src/app/lib/metadata.spec.js
+++ b/src/app/lib/metadata.spec.js
@@ -697,6 +697,15 @@ describe( 'metadata', () => {
 							'2': 'My team barriers',
 						}
 					},
+					assessment: {
+						fieldNames: {
+							impact: 'Economic assessment',
+							value_to_economy: 'Value to UK Economy',
+							import_market_size: 'Import Market Size',
+							export_value: 'Value of currently affected UK exports',
+							commercial_value: 'Commercial Value'
+						}
+					}
 				} );
 			} );
 		} );

--- a/src/app/lib/metadata.spec.js
+++ b/src/app/lib/metadata.spec.js
@@ -602,6 +602,12 @@ describe( 'metadata', () => {
 					expect( metadata.barrierPendingOptions ).toEqual( fakeData.barrier_pending );
 				} );
 			} );
+
+			describe( 'barrierAssessmentImpactOptions', () => {
+				it( 'Should return the options', () => {
+					expect( metadata.barrierAssessmentImpactOptions ).toEqual( fakeData.assessment_impact );
+				} );
+			} );
 		} );
 
 		describe( 'getBarrierCreatedBy', () => {

--- a/src/app/lib/nunjucks-filters/format-number.js
+++ b/src/app/lib/nunjucks-filters/format-number.js
@@ -1,0 +1,15 @@
+module.exports = ( value ) => {
+
+	const type = typeof value;
+
+	if( type === 'string' && value ){
+
+		value = Number( value );
+
+	} else if( type !== 'number' ){
+
+		return value;
+	}
+
+	return value.toLocaleString();
+};

--- a/src/app/lib/nunjucks-filters/format-number.spec.js
+++ b/src/app/lib/nunjucks-filters/format-number.spec.js
@@ -1,0 +1,30 @@
+const formatNumber = require( './format-number' );
+
+describe( 'Format number filter', () => {
+	describe( 'When there is no value input', () => {
+		it( 'Should return the input', () => {
+
+			expect( formatNumber() ).toEqual();
+			expect( formatNumber( '' ) ).toEqual( '' );
+		} );
+	} );
+
+	describe( 'When there is a number', () => {
+		it( 'Should format it correctly', () => {
+
+			const values = [
+				[ '0', '0' ],
+				[ '100', '100' ],
+				[ '1000', '1,000' ],
+				[ '20000', '20,000' ],
+				[ '300000', '300,000' ],
+				[ '4000000', '4,000,000' ],
+			];
+
+			for( const [ input, output ] of values ){
+
+				expect( formatNumber( input ) ).toEqual( output );
+			}
+		} );
+	} );
+} );

--- a/src/app/lib/nunjucks-filters/index.js
+++ b/src/app/lib/nunjucks-filters/index.js
@@ -9,4 +9,5 @@ module.exports = function( env ){
 	env.addFilter( 'addToRadio', require( './add-to-radio' ) );
 	env.addFilter( 'time', require( './time' ) );
 	env.addFilter( 'linkify', require( './linkify' ) );
+	env.addFilter( 'formatNumber', require( './format-number' ) );
 };

--- a/src/app/lib/nunjucks-filters/index.spec.js
+++ b/src/app/lib/nunjucks-filters/index.spec.js
@@ -17,6 +17,7 @@ describe( 'Nunjucks filters', function(){
 		[ './add-to-radio', 'addToRadio' ],
 		[ './time', 'time' ],
 		[ './linkify', 'linkify' ],
+		[ './format-number', 'formatNumber' ],
 	];
 
 	beforeEach( function(){

--- a/src/app/lib/urls.js
+++ b/src/app/lib/urls.js
@@ -163,7 +163,10 @@ module.exports = {
 		},
 		assessment: {
 			detail: ( barrierId ) => `/barriers/${ barrierId }/assessment/`,
-			economic: ( barrierId ) => `/barriers/${ barrierId }/assessment/economic/`,
+			economic: {
+				list: ( barrierId ) => `/barriers/${ barrierId }/assessment/economic/`,
+				new: ( barrierId ) => `/barriers/${ barrierId }/assessment/economic/new/`,
+			} ,
 			economyValue: ( barrierId ) => `/barriers/${ barrierId }/assessment/economy-value/`,
 			marketSize: ( barrierId ) => `/barriers/${ barrierId }/assessment/market-size/`,
 			exportValue: ( barrierId ) => `/barriers/${ barrierId }/assessment/export-value/`,

--- a/src/app/lib/urls.js
+++ b/src/app/lib/urls.js
@@ -161,6 +161,14 @@ module.exports = {
 			//edit: ( barrierId, memberId ) => `/barriers/${ barrierId }/team/edit/${ memberId }`,
 			delete: ( barrierId, memberId ) => `/barriers/${ barrierId }/team/delete/${ memberId }`,
 		},
+		assessment: {
+			detail: ( barrierId ) => `/barriers/${ barrierId }/assessment/`,
+			economic: ( barrierId ) => `/barriers/${ barrierId }/assessment/economic/`,
+			economyValue: ( barrierId ) => `/barriers/${ barrierId }/assessment/economy-value/`,
+			marketSize: ( barrierId ) => `/barriers/${ barrierId }/assessment/market-size/`,
+			exportValue: ( barrierId ) => `/barriers/${ barrierId }/assessment/export-value/`,
+			commercialValue: ( barrierId ) => `/barriers/${ barrierId }/assessment/commercial-value/`,
+		}
 	},
 
 	reports: reportUrl,

--- a/src/app/lib/urls.js
+++ b/src/app/lib/urls.js
@@ -168,6 +168,11 @@ module.exports = {
 			marketSize: ( barrierId ) => `/barriers/${ barrierId }/assessment/market-size/`,
 			exportValue: ( barrierId ) => `/barriers/${ barrierId }/assessment/export-value/`,
 			commercialValue: ( barrierId ) => `/barriers/${ barrierId }/assessment/commercial-value/`,
+			documents: {
+				add: ( barrierId ) => `/barriers/${ barrierId }/assessment/documents/add/`,
+				cancel: ( barrierId ) => `/barriers/${ barrierId }/assessment/documents/cancel/`,
+				delete: ( barrierId, documentId ) => `/barriers/${ barrierId }/assessment/documents/${ documentId }/delete/`,
+			},
 		}
 	},
 

--- a/src/app/lib/urls.spec.js
+++ b/src/app/lib/urls.spec.js
@@ -299,12 +299,20 @@ describe( 'URLs', () => {
 
 		describe( 'assessment', () => {
 			it( 'Should return the correct paths', () => {
+
 				expect( urls.barriers.assessment.detail( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/` );
-				expect( urls.barriers.assessment.economic( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/economic/` );
+				expect( urls.barriers.assessment.economic.list( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/economic/` );
+				expect( urls.barriers.assessment.economic.new( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/economic/new/` );
 				expect( urls.barriers.assessment.economyValue( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/economy-value/` );
 				expect( urls.barriers.assessment.marketSize( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/market-size/` );
 				expect( urls.barriers.assessment.exportValue( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/export-value/` );
 				expect( urls.barriers.assessment.commercialValue( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/commercial-value/` );
+
+				const documentId = uuid();
+
+				expect( urls.barriers.assessment.documents.add( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/documents/add/` );
+				expect( urls.barriers.assessment.documents.cancel( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/documents/cancel/` );
+				expect( urls.barriers.assessment.documents.delete( barrierId, documentId ) ).toEqual( `/barriers/${ barrierId }/assessment/documents/${ documentId }/delete/` );
 			} );
 		} );
 	} );

--- a/src/app/lib/urls.spec.js
+++ b/src/app/lib/urls.spec.js
@@ -296,6 +296,17 @@ describe( 'URLs', () => {
 				});
 			} );
 		} );
+
+		describe( 'assessment', () => {
+			it( 'Should return the correct paths', () => {
+				expect( urls.barriers.assessment.detail( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/` );
+				expect( urls.barriers.assessment.economic( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/economic/` );
+				expect( urls.barriers.assessment.economyValue( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/economy-value/` );
+				expect( urls.barriers.assessment.marketSize( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/market-size/` );
+				expect( urls.barriers.assessment.exportValue( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/export-value/` );
+				expect( urls.barriers.assessment.commercialValue( barrierId ) ).toEqual( `/barriers/${ barrierId }/assessment/commercial-value/` );
+			} );
+		} );
 	} );
 
 	describe( 'Report urls', () => {

--- a/src/app/lib/validators.js
+++ b/src/app/lib/validators.js
@@ -54,4 +54,11 @@ module.exports = {
 	isCountryOrAdminArea: ( id ) => isCountry( id ) || isCountryAdminArea( id ),
 	isBarrierStatus: ( id ) => metadata.barrierStatuses.hasOwnProperty( id ),
 	isCreatedBy: ( id ) => metadata.barrier.createdBy.items.hasOwnProperty( id ),
+	isFileOverSize: ( err ) => {
+
+		const message = err.message;
+		const isOverSize = ( message.indexOf( 'maxFileSize exceeded' ) >= 0 );
+
+		return isOverSize;
+	}
 };

--- a/src/app/sub-apps/barriers/controllers/assessment.js
+++ b/src/app/sub-apps/barriers/controllers/assessment.js
@@ -25,7 +25,7 @@ function createValueController( opts ){
 		const processor = new FormProcessor( {
 			form,
 			render: ( templateValues ) => res.render( `barriers/views/assessment/${ opts.template }`, templateValues ),
-			saveFormData: ( formValues ) => backend.barriers.assessment[ opts.serviceMethod ]( req, req.barrier.id, formValues.value ),
+			saveFormData: ( formValues ) => backend.barriers.assessment[ opts.serviceMethod ]( req, req.barrier, formValues.value ),
 			saved: () => res.redirect( urls.barriers.assessment.detail( req.barrier.id ) )
 		} );
 
@@ -92,7 +92,7 @@ module.exports = {
 		const processor = new FormProcessor( {
 			form,
 			render: ( templateValues ) => res.render( 'barriers/views/assessment/economic', templateValues ),
-			saveFormData: ( formValues ) => backend.barriers.assessment.create( req, req.barrier.id, formValues ),
+			saveFormData: ( formValues ) => backend.barriers.assessment.saveEconomic( req, req.barrier, formValues ),
 			saved: () => res.redirect( urls.barriers.assessment.detail( req.barrier.id ) )
 		} );
 

--- a/src/app/sub-apps/barriers/controllers/assessment.js
+++ b/src/app/sub-apps/barriers/controllers/assessment.js
@@ -98,7 +98,7 @@ module.exports = {
 
 		try {
 
-			await processor.process({ checkResponseErrors: true });
+			await processor.process();
 
 		} catch( e ){
 

--- a/src/app/sub-apps/barriers/controllers/assessment.js
+++ b/src/app/sub-apps/barriers/controllers/assessment.js
@@ -1,0 +1,128 @@
+const metadata = require( '../../../lib/metadata' );
+const backend = require( '../../../lib/backend-service' );
+const urls = require( '../../../lib/urls' );
+const Form = require( '../../../lib/Form' );
+const FormProcessor = require( '../../../lib/FormProcessor' );
+const validators = require( '../../../lib/validators' );
+const govukItemsFromObject = require( '../../../lib/govuk-items-from-object' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
+const detailViewModel = require( '../view-models/detail' );
+
+function createValueController( opts ){
+
+	return async ( req, res, next ) => {
+
+		const form = new Form( req, {
+			value: {
+				required: 'Enter a value',
+				validators: [{
+					fn: validators.isNumeric,
+					message: 'Value is not a number'
+				}]
+			}
+		} );
+
+		const processor = new FormProcessor( {
+			form,
+			render: ( templateValues ) => res.render( `barriers/views/assessment/${ opts.template }`, templateValues ),
+			saveFormData: ( formValues ) => backend.barriers.assessment[ opts.serviceMethod ]( req, req.barrier.id, formValues.value ),
+			saved: () => res.redirect( urls.barriers.assessment.detail( req.barrier.id ) )
+		} );
+
+		try {
+
+			await processor.process();
+
+		} catch( e ){
+
+			next( e );
+		}
+	};
+}
+
+module.exports = {
+
+	list: async( req, res, next ) => {
+
+		try {
+
+			const { response, body } = await backend.barriers.assessment.get( req, req.barrier.id );
+
+			if( response.isSuccess ){
+
+				res.render( 'barriers/views/assessment/detail', {
+					...detailViewModel( req.barrier ),
+					assessment: body,
+					impactScale: Object.entries( metadata.barrierAssessmentImpactOptions ).map( ( [ key, text ] ) => ({
+						isActive: ( key === body.impact ),
+						text,
+					}) )
+				} );
+
+			} else if( response.statusCode === 404 ){
+
+				res.render( 'barriers/views/assessment/detail', {
+					...detailViewModel( req.barrier ),
+				} );
+
+			} else {
+
+				throw new HttpResponseError( 'Unable to get barrier assessment', response, body );
+			}
+
+		} catch( e ){
+
+			next( e );
+		}
+	},
+
+	economic: async ( req, res, next ) => {
+
+		const form = new Form( req, {
+			impact: {
+				type: Form.RADIO,
+				required: 'Select an economic impact',
+				items: govukItemsFromObject( metadata.barrierAssessmentImpactOptions ),
+			},
+			description: {
+				required: 'Explain the assessment'
+			}
+		} );
+
+		const processor = new FormProcessor( {
+			form,
+			render: ( templateValues ) => res.render( 'barriers/views/assessment/economic', templateValues ),
+			saveFormData: ( formValues ) => backend.barriers.assessment.create( req, req.barrier.id, formValues ),
+			saved: () => res.redirect( urls.barriers.assessment.detail( req.barrier.id ) )
+		} );
+
+		try {
+
+			await processor.process({ checkResponseErrors: true });
+
+		} catch( e ){
+
+			next( e );
+		}
+	},
+
+	economyValue: createValueController({
+		template: 'economy-value',
+		serviceMethod: 'saveEconomyValue',
+	}),
+
+	marketSize: createValueController({
+		template: 'market-size',
+		serviceMethod: 'saveMarketSize',
+	}),
+
+	exportValue: createValueController({
+		template: 'export-value',
+		serviceMethod: 'saveExportValue',
+	}),
+
+	commercialValue: createValueController({
+		template: 'commercial-value',
+		serviceMethod: 'saveCommercialValue',
+	}),
+};

--- a/src/app/sub-apps/barriers/controllers/assessment.js
+++ b/src/app/sub-apps/barriers/controllers/assessment.js
@@ -143,10 +143,7 @@ module.exports = {
 			form,
 			render: ( templateValues ) => res.render(
 				'barriers/views/assessment/economic',
-				{
-					documents: assessment.documents,
-					...economicViewModel( barrierId, session.get(), templateValues )
-				}
+				economicViewModel( barrierId, session.get(), templateValues )
 			),
 			saveFormData: async ( formValues ) => {
 

--- a/src/app/sub-apps/barriers/controllers/assessment.js
+++ b/src/app/sub-apps/barriers/controllers/assessment.js
@@ -21,9 +21,9 @@ function createValueController( { template, serviceMethod, valueProp } ){
 				required: 'Enter a value',
 				validators: [{
 					fn: validators.isNumeric,
-					message: 'Value is not a number'
+					message: 'Enter a whole number'
 				}],
-				values: [ ]
+				sanitize: ( value ) => value.replace( /,/g, '' ),
 			}
 		};
 

--- a/src/app/sub-apps/barriers/controllers/assessment.spec.js
+++ b/src/app/sub-apps/barriers/controllers/assessment.spec.js
@@ -1,0 +1,335 @@
+const proxyquire = require( 'proxyquire' );
+const faker = require( 'faker' );
+const fileSize = require( '../../../lib/file-size' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
+const modulePath = './assessment';
+const { mocks, getFakeData } = jasmine.helpers;
+
+describe( 'Assessment controller', () => {
+
+	let controller;
+	let backend;
+	let req;
+	let res;
+	let next;
+	let barrier;
+	let barrierDetailViewModel;
+	let metadata;
+	let urls;
+	let documentControllers;
+	let barrierSession;
+	let getValuesResponse;
+	let getTemplateValuesResponse;
+	let form;
+	let Form;
+	let FormProcessor;
+	let validators;
+
+	beforeEach( () => {
+
+		({ req, res, next } = mocks.middleware());
+		documentControllers = mocks.documentControllers();
+		barrierSession = mocks.barrierSession();
+		({ getValuesResponse, getTemplateValuesResponse, form, Form } = mocks.form() );
+		FormProcessor = mocks.formProcessor();
+
+		backend = {
+			barriers: {
+				assessment: {
+					get: jasmine.createSpy( 'backend.barriers.assessment.get' ),
+					saveEconomyValue: jasmine.createSpy( 'backend.barriers.assessment.saveEconomyValue' ),
+					saveMarketSize: jasmine.createSpy( 'backend.barriers.assessment.saveMarketSize' ) ,
+					saveExportValue: jasmine.createSpy( 'backend.barriers.assessment.saveExportValue' ) ,
+					saveCommercialValue: jasmine.createSpy( 'backend.barriers.assessment.saveCommercialValue' ),
+				}
+			}
+		};
+
+		metadata = {
+			documentStatus: {
+				virus_scanned: 'scanned'
+			},
+			barrierAssessmentImpactOptions: {
+				THREE: 'Three text',
+			},
+		};
+
+		barrier = {
+			id: faker.random.uuid(),
+			title: faker.lorem.words(),
+		};
+
+		urls = {
+			barriers: {
+				assessment: {
+					detail: jasmine.createSpy( 'urls.barriers.assessment.detail' ),
+				}
+			}
+		};
+
+		barrierDetailViewModel = jasmine.createSpy( 'barrierDetailViewModel' );
+
+		validators = {
+			isNumeric: jasmine.createSpy( 'validators.isNumeric' ),
+		};
+
+		req.barrier = barrier;
+		req.barrierSession = barrierSession;
+
+		controller = proxyquire( modulePath, {
+			'../../../lib/metadata': metadata,
+			'../../../lib/backend-service': backend,
+			'../view-models/detail': barrierDetailViewModel,
+			'../../../lib/urls': urls,
+			'../../../lib/document-controllers': documentControllers,
+			'../../../lib/Form': Form,
+			'../../../lib/FormProcessor': FormProcessor,
+			'../../../lib/validators': validators,
+		} );
+	} );
+
+	describe( '#detail', () => {
+
+		const template = 'barriers/views/assessment/detail';
+
+		describe( 'When the backend call rejects', () => {
+			it( 'Calls next with an error', async () => {
+
+				const err = new Error( 'A backend assessment issue' );
+
+				backend.barriers.assessment.get.and.returnValue( Promise.reject( err ) );
+				await controller.detail( req, res, next );
+
+				expect( next ).toHaveBeenCalledWith( err );
+			} );
+		} );
+
+		describe( 'When the backend resolves with a 500', () => {
+			it( 'Calls next with an error', async () => {
+
+				backend.barriers.assessment.get.and.returnValue( mocks.request( 500 ) );
+
+				await controller.detail( req, res, next );
+
+				expect( next ).toHaveBeenCalled();
+				expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
+			} );
+		} );
+
+		describe( 'When the backend resolves with a 404', () => {
+			it( 'Renders the assessment detail', async () => {
+
+				const barrierDetailViewModelResponse = { d: 1, e: 2 };
+
+				backend.barriers.assessment.get.and.returnValue( mocks.request( 404 ) );
+				barrierDetailViewModel.and.returnValue( barrierDetailViewModelResponse );
+
+				await controller.detail( req, res, next );
+
+				expect( res.render ).toHaveBeenCalledWith( template, barrierDetailViewModelResponse );
+				expect( barrierDetailViewModel ).toHaveBeenCalledWith( barrier );
+			} );
+		} );
+
+		describe( 'When the backend resolves with a 200', () => {
+			it( 'Renders the assessment detail with the assessment data', async () => {
+
+				const barrierDetailViewModelResponse = { e: 1, f: 2 };
+				const assessment = getFakeData( '/backend/barriers/assessment' );
+
+				backend.barriers.assessment.get.and.returnValue( mocks.request( 200, assessment ) );
+				barrierDetailViewModel.and.returnValue( barrierDetailViewModelResponse );
+
+				await controller.detail( req, res, next );
+
+				expect( res.render ).toHaveBeenCalledWith( template, {
+					...barrierDetailViewModelResponse,
+					assessment,
+					impact: {
+						text: metadata.barrierAssessmentImpactOptions[ assessment.impact ],
+						id: assessment.impact,
+					},
+					documents: assessment.documents.map( ( doc ) => ({
+						id: doc.id,
+						name: doc.name,
+						size: fileSize( doc.size ),
+						canDownload: ( doc.status === 'virus_scanned' ),
+						status: metadata.documentStatus[ doc.status ]
+					}) ),
+				} );
+				expect( barrierDetailViewModel ).toHaveBeenCalledWith( barrier );
+				expect( next ).not.toHaveBeenCalled();
+			} );
+		} );
+	} );
+
+	describe( 'documents', () => {
+
+		let barrierId;
+		let noteId;
+		let documentId;
+
+		beforeEach( () => {
+
+			barrierId = faker.random.uuid();
+			documentId = faker.random.uuid();
+			noteId = 123;
+
+			req.uuid = barrierId;
+			req.note = { id: noteId };
+			req.params.id = documentId;
+		} );
+
+		describe( 'add', () => {
+			it( 'Uses the documentControllers and adds the document to the session', async () => {
+
+				const document = { type: 'text/plain', size: 10, name: 'test-1.txt' };
+				const mockDocuments = [];
+
+				req.body.document = document;
+				barrierSession.documents.assessment.get.and.returnValue( mockDocuments );
+
+				expect( controller.documents.add ).toEqual( documentControllers.xhr.add.cb );
+
+				documentControllers.xhr.add.calls.argsFor( 0 )[ 0 ]( req, { ...document, id: documentId } );
+
+				expect( barrierSession.documents.assessment.setIfNotAlready ).toHaveBeenCalledWith( [] );
+				expect( barrierSession.documents.assessment.get ).toHaveBeenCalledWith();
+				expect( mockDocuments ).toEqual( [ {
+					...document,
+					id: documentId
+				} ] );
+			} );
+		} );
+
+		describe( 'delete', () => {
+			it( 'Uses the documentControllers', () => {
+
+				expect( controller.documents.delete ).toEqual( documentControllers.xhr.delete.cb );
+				const args = documentControllers.xhr.delete.calls.argsFor( 0 );
+				expect( typeof args[ 0 ] ).toEqual( 'function' );
+				expect( typeof args[ 1 ] ).toEqual( 'function' );
+				expect( args[ 0 ]( req ) ).toEqual( documentId );
+			} );
+
+			describe( 'When there are barrier documents in the session', () => {
+				it( 'Should remove the document from the session', () => {
+
+					const nonMatchingDoc1 = { id: faker.random.uuid(), name: 'test1.jpg' };
+					const matchingDoc = { id: documentId, name: 'match.txt' };
+					const mockDocuments = [
+						nonMatchingDoc1,
+						matchingDoc,
+					];
+
+					barrierSession.documents.assessment.get.and.returnValue( mockDocuments );
+					documentControllers.xhr.delete.calls.argsFor( 0 )[ 1 ]( req, documentId );
+
+					expect( barrierSession.documents.assessment.set ).toHaveBeenCalledWith( [ nonMatchingDoc1 ] );
+				} );
+			} );
+
+			describe( 'When there are no documents in the session', () => {
+				it( 'Should not error and have no documents in the session', () => {
+
+					documentControllers.xhr.delete.calls.argsFor( 0 )[ 1 ]( req, documentId );
+
+					expect( barrierSession.documents.assessment.set ).not.toHaveBeenCalled();
+				} );
+			} );
+		} );
+
+		describe( 'cancel', () => {
+			describe( 'When there are documents in the session', () => {
+				it( 'Should remove ones matched to the current barrier and redirect to the barrier detail', () => {
+
+					const detailResponse = 'detail/x/y/z';
+					urls.barriers.assessment.detail.and.returnValue( detailResponse );
+
+					controller.documents.cancel( req, res );
+
+					expect( barrierSession.documents.assessment.delete ).toHaveBeenCalled();
+					expect( res.redirect ).toHaveBeenCalledWith( detailResponse );
+					expect( urls.barriers.assessment.detail ).toHaveBeenCalledWith( barrierId );
+				} );
+			} );
+		} );
+	} );
+
+	function checkValueController( templateName, serviceMethod ){
+
+		const template = `barriers/views/assessment/${ templateName }`;
+		const backendMethod = backend.barriers.assessment[ serviceMethod ];
+		const detailResponse = '/a/detail/page';
+
+		urls.barriers.assessment.detail.and.returnValue( detailResponse );
+
+		const formArgs = Form.calls.argsFor( 0 );
+		const formConfig = formArgs[ 1 ];
+
+		expect( formArgs[ 0 ] ).toEqual( req );
+		expect( formConfig.value ).toBeDefined();
+		expect( formConfig.value.required ).toBeDefined();
+		expect( formConfig.value.validators.length ).toEqual( 1 );
+		expect( formConfig.value.validators[ 0 ].fn ).toEqual( validators.isNumeric );
+
+		expect( FormProcessor ).toHaveBeenCalled();
+		const processorArgs = FormProcessor.calls.argsFor( 0 )[ 0 ];
+
+		expect( processorArgs.form ).toEqual( form );
+		expect( processorArgs.render ).toBeDefined();
+		expect( processorArgs.saveFormData ).toBeDefined();
+		expect( processorArgs.saved ).toBeDefined();
+
+		processorArgs.render( getTemplateValuesResponse );
+
+		expect( res.render ).toHaveBeenCalledWith( template, getTemplateValuesResponse );
+
+		processorArgs.saveFormData( getValuesResponse );
+
+		expect( backendMethod ).toHaveBeenCalledWith( req, req.barrier, getValuesResponse.value );
+
+		processorArgs.saved();
+
+		expect( res.redirect ).toHaveBeenCalledWith( detailResponse );
+		expect( urls.barriers.assessment.detail ).toHaveBeenCalledWith( barrier.id );
+
+		expect( FormProcessor.processor.process ).toHaveBeenCalled();
+	}
+
+	describe( '#economyValue', () => {
+		it( 'configures the form processor correctly', async () => {
+
+			await controller.economyValue( req, res, next );
+
+			checkValueController( 'economy-value', 'saveEconomyValue' );
+		} );
+	} );
+
+	describe( '#marketSize', () => {
+		it( 'configures the form processor correctly', async () => {
+
+			await controller.marketSize( req, res, next );
+
+			checkValueController( 'market-size', 'saveMarketSize' );
+		} );
+	} );
+
+	describe( '#exportValue', () => {
+		it( 'configures the form processor correctly', async () => {
+
+			await controller.exportValue( req, res, next );
+
+			checkValueController( 'export-value', 'saveExportValue' );
+		} );
+	} );
+
+	describe( '#commercialValue', () => {
+		it( 'configures the form processor correctly', async () => {
+
+			await controller.commercialValue( req, res, next );
+
+			checkValueController( 'commercial-value', 'saveCommercialValue' );
+		} );
+	} );
+} );

--- a/src/app/sub-apps/barriers/controllers/assessment.spec.js
+++ b/src/app/sub-apps/barriers/controllers/assessment.spec.js
@@ -62,9 +62,11 @@ describe( 'Assessment controller', () => {
 			barriers: {
 				assessment: {
 					detail: jasmine.createSpy( 'urls.barriers.assessment.detail' ),
-					economic: jasmine.createSpy( 'urls.barriers.assessment.economic' ),
-				}
-			}
+					economic: {
+						list: jasmine.createSpy( 'urls.barriers.assessment.economic.list' ),
+					},
+				},
+			},
 		};
 
 		barrierDetailViewModel = jasmine.createSpy( 'barrierDetailViewModel' );
@@ -180,7 +182,7 @@ describe( 'Assessment controller', () => {
 			it( 'Uses the documentControllers', () => {
 
 				const economicUrlResponse = 'a/b/c/';
-				urls.barriers.assessment.economic.and.returnValue( economicUrlResponse );
+				urls.barriers.assessment.economic.list.and.returnValue( economicUrlResponse );
 				expect( controller.documents.delete ).toEqual( documentControllers.delete.cb );
 				const args = documentControllers.delete.calls.argsFor( 0 );
 
@@ -190,7 +192,7 @@ describe( 'Assessment controller', () => {
 
 				expect( args[ 0 ]( req ) ).toEqual( documentId );
 				expect( args[ 1 ]( req ) ).toEqual( economicUrlResponse );
-				expect( urls.barriers.assessment.economic ).toHaveBeenCalledWith( barrierId, documentId );
+				expect( urls.barriers.assessment.economic.list ).toHaveBeenCalledWith( barrierId, documentId );
 
 			} );
 

--- a/src/app/sub-apps/barriers/controllers/index.js
+++ b/src/app/sub-apps/barriers/controllers/index.js
@@ -7,4 +7,5 @@ module.exports = {
 	sectors: require( './sectors' ),
 	companies: require( './companies' ),
 	team: require( './team' ),
+	assessment: require( './assessment' ),
 };

--- a/src/app/sub-apps/barriers/controllers/interactions.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.js
@@ -17,18 +17,22 @@ function getTimelineData( req, barrierId ){
 
 	return new Promise( async ( resolve, reject ) => {
 
+		const hasAssessment = req.barrier.has_assessment;
+
 		try {
 
-			const [ interactions, history ] = await Promise.all( [
+			const [ interactions, history, assessmentHistory ] = await Promise.all( [
 				backend.barriers.getInteractions( req, barrierId ),
-				backend.barriers.getHistory( req, barrierId )
+				backend.barriers.getHistory( req, barrierId ),
+				( hasAssessment ? backend.barriers.assessment.getHistory( req, barrierId ) : Promise.resolve() ),
 			]);
 
 			if( interactions.response.isSuccess && history.response.isSuccess ){
 
 				resolve( {
 					interactions: interactions.body,
-					history: history.body
+					history: history.body,
+					assessmentHistory,
 				} );
 
 			} else {

--- a/src/app/sub-apps/barriers/controllers/interactions.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.js
@@ -1,6 +1,4 @@
 const config = require( '../../../config' );
-const metadata = require( '../../../lib/metadata' );
-const reporter = require( '../../../lib/reporter' );
 const backend = require( '../../../lib/backend-service' );
 const Form = require( '../../../lib/Form' );
 const FormProcessor = require( '../../../lib/FormProcessor' );
@@ -10,32 +8,10 @@ const fileSize = require( '../../../lib/file-size' );
 const uploadDocument = require( '../../../lib/upload-document' );
 const detailVieWModel = require( '../view-models/detail' );
 const interactionsViewModel = require( '../view-models/interactions' );
+const documentControllers = require( '../../../lib/document-controllers' );
 
-const MAX_FILE_SIZE = fileSize( config.files.maxSize );
-const OVERSIZE_FILE_MESSAGE = `File size exceeds the ${ MAX_FILE_SIZE } limit. Reduce file size and upload the document again.`;
 const NOTE_ERROR = 'Add text for the note.';
-const INVALID_FILE_TYPE_MESSAGE = `Unsupported file format. The following file formats are accepted ${ getValidTypes() }`;
-const UPLOAD_ERROR_MESSAGE = 'A system error has occured, so the file has not been uploaded. Try again.';
-const DELETE_ERROR_MESSAGE = 'A system error has occured, so the file has not been deleted. Try again.';
-const FILE_INFECTED_MESSAGE = 'This file may be infected with a virus and will not be accepted.';
-
-function getValidTypes(){
-
-	const types = [];
-
-	config.files.types.forEach( ( type ) => {
-
-		const file = metadata.mimeTypes[ type ];
-
-		if( file ){ types.push( file ); return; }
-
-		reporter.message( 'info', 'No file extension mapping found for valid type: ' + type );
-
-		types.push( type );
-	} );
-
-	return types.join( ', ' );
-}
+const { OVERSIZE_FILE_MESSAGE, INVALID_FILE_TYPE_MESSAGE, FILE_INFECTED_MESSAGE } = documentControllers;
 
 function getTimelineData( req, barrierId ){
 
@@ -95,18 +71,6 @@ async function renderInteractions( req, res, next, opts = {} ){
 	}
 }
 
-function isFileOverSize( err ){
-
-	const message = err.message;
-	const isOverSize = ( message.indexOf( 'maxFileSize exceeded' ) >= 0 );
-
-	return isOverSize;
-}
-
-function reportInvalidFile( file = {} ){
-	reporter.message( 'info', 'Invalid document type: ' + file.type, { size: file.size, name: file.name } );
-}
-
 async function handleNoteForm( req, res, next, opts ){
 
 	const barrier = req.barrier;
@@ -124,7 +88,7 @@ async function handleNoteForm( req, res, next, opts ){
 
 						if( !isValid ){
 
-							reportInvalidFile( file );
+							documentControllers.reportInvalidFile( file );
 						}
 
 						return isValid;
@@ -135,7 +99,7 @@ async function handleNoteForm( req, res, next, opts ){
 		}
 	} );
 
-	if( req.formError && isFileOverSize( req.formError ) ){
+	if( req.formError && validators.isFileOverSize( req.formError ) ){
 
 		form.addErrors( { document: OVERSIZE_FILE_MESSAGE } );
 	}
@@ -249,107 +213,21 @@ function removeAllNoteDocumentsInSession( { session }, noteIdToMatch ){
 	}
 }
 
-function createUploadHandler( passedCb ){
-	return async ( req, res ) => {
-
-		const document = req.body.document;
-
-		if( req.formError ){
-
-			const isOverSize = isFileOverSize( req.formError );
-
-			res.status( 400 );
-			res.json( { message: ( isOverSize ? OVERSIZE_FILE_MESSAGE : UPLOAD_ERROR_MESSAGE ) } );
-
-			if( !isOverSize ){
-
-				reporter.captureException( req.formError );
-			}
-
-		} else if( document && validators.isValidFile( document ) ){
-
-			try {
-
-				const documentId = await uploadDocument( req, document );
-				const { passed } = await backend.documents.getScanStatus( req, documentId );
-
-				if( passed ){
-
-					passedCb( req, {
-						id: documentId,
-						size: fileSize( document.size ),
-						name: document.name,
-					} );
-
-					res.json( {
-						documentId,
-						file: { name: document.name, size: fileSize( document.size ) },
-					} );
-
-				} else {
-
-					res.status( 401 );
-					res.json( { message: FILE_INFECTED_MESSAGE } );
-				}
-
-			} catch( e ){
-
-				res.status( 500 );
-				res.json( { message: UPLOAD_ERROR_MESSAGE } );
-				reporter.captureException( e );
-			}
-
-		} else {
-
-			res.status( 400 );
-			res.json( { message: INVALID_FILE_TYPE_MESSAGE } );
-			reportInvalidFile( document );
-		}
-	};
-}
-
 module.exports = {
 
 	list: renderInteractions,
 
 	documents: {
-		add: createUploadHandler( ( req, document ) => {
+		add: documentControllers.xhr.add( ( req, document ) => {
 
 			req.session.barrierDocuments = req.session.barrierDocuments || [];
 			req.session.barrierDocuments.push( { barrierId: req.uuid, document } );
 		} ),
 
-		delete: async ( req, res ) => {
+		delete: documentControllers.xhr.delete( ( req ) => req.params.id, ( req, documentId ) => {
 
-			const { uuid: barrierId } = req;
-			const { id: documentId } = req.params;
-
-			try {
-
-				if( !validators.isUuid( documentId ) ){ throw new Error( 'Invalid documentId' ); }
-
-				const { response } = await backend.documents.delete( req, documentId );
-
-				if( response.isSuccess || response.statusCode === 404 ){
-
-					removeBarrierDocumentInSession( req, barrierId, documentId );
-					res.status( 200 );
-					res.json( {} );
-
-				} else {
-
-					res.status( 500 );
-					res.json( { message: DELETE_ERROR_MESSAGE } );
-					reporter.captureException( new Error( `Unable to delete document ${ documentId }, got ${ response.statusCode } from backend` ) );
-				}
-
-			} catch ( e ){
-
-				res.status( 500 );
-				res.json( {} );
-				reporter.captureException( e );
-			}
-		},
+			removeBarrierDocumentInSession( req, req.uuid, documentId );
+		} ),
 
 		cancel: ( req, res ) => {
 
@@ -362,7 +240,7 @@ module.exports = {
 
 	notes: {
 		documents: {
-			add: createUploadHandler( ( req, document ) => {
+			add: documentControllers.xhr.add( ( req, document ) => {
 
 				const noteId = req.note.id;
 
@@ -370,48 +248,11 @@ module.exports = {
 				req.session.noteDocuments[ noteId ] = req.session.noteDocuments[ noteId ] || [];
 				req.session.noteDocuments[ noteId ].push( { document } );
 			} ),
-			delete: async ( req, res, next ) => {
-
-				const { uuid: barrierId, note } = req;
-				const documentId = req.params.id;
-				const isJson = req.method === 'POST';
-
-				try {
-
-					const { response } = await backend.documents.delete( req, documentId );
-
-					if( response.isSuccess || response.statusCode === 400 ){
-
-						removeNoteDocumentInSession( req, note.id, documentId );
-
-						if( isJson ){
-
-							res.json( {} );
-
-						} else {
-
-							res.redirect( urls.barriers.notes.edit( barrierId, note.id ) );
-						}
-
-					} else {
-
-						throw new Error( `Unable to delete document ${ documentId }, got ${ response.statusCode } from backend` );
-					}
-
-				} catch ( e ){
-
-					if( isJson ){
-
-						res.status( 500 );
-						res.json( { message: 'Error deleting file' } );
-						reporter.captureException( e );
-
-					} else {
-
-						next( e );
-					}
-				}
-			},
+			delete: documentControllers.delete(
+				( req ) => req.params.id,
+				( req ) => urls.barriers.notes.edit( req.uuid, req.note.id ),
+				( req, documentId ) => removeNoteDocumentInSession( req, req.note.id, documentId ),
+			),
 			cancel: ( req, res ) => {
 
 				removeAllNoteDocumentsInSession( req, req.note.id );

--- a/src/app/sub-apps/barriers/controllers/interactions.spec.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.spec.js
@@ -27,6 +27,7 @@ describe( 'Barrier interactions controller', () => {
 	let barrierId;
 	let uploadDocument;
 	let reporter;
+	let documentControllers;
 
 	beforeEach( () => {
 
@@ -106,6 +107,7 @@ describe( 'Barrier interactions controller', () => {
 		};
 
 		reporter = mocks.reporter();
+		documentControllers = mocks.documentControllers();
 
 		controller = proxyquire( modulePath, {
 			'../../../config': config,
@@ -118,6 +120,7 @@ describe( 'Barrier interactions controller', () => {
 			'../view-models/interactions': interactionsViewModel,
 			'../../../lib/upload-document': uploadDocument,
 			'../../../lib/reporter': reporter,
+			'../../../lib/document-controllers': documentControllers,
 		} );
 	} );
 
@@ -174,166 +177,6 @@ describe( 'Barrier interactions controller', () => {
 			...data
 		} );
 	}
-
-	function checkAddDocument( getMethod, passedCb ){
-
-		let method;
-
-		beforeEach( () => {
-
-			method = getMethod();
-		} );
-
-		describe( 'When there is a formError on the req', () => {
-			describe( 'When the error is about file size', () => {
-				it( 'Should return a 400 with a message', async () => {
-
-					req.formError = new Error( 'The error is maxFileSize exceeded' );
-
-					await method( req, res );
-
-					expect( res.status ).toHaveBeenCalledWith( 400 );
-					expect( res.json ).toHaveBeenCalledWith( { message: 'File size exceeds the 5 MB limit. Reduce file size and upload the document again.' } );
-					expect( reporter.message ).not.toHaveBeenCalled();
-					expect( reporter.captureException ).not.toHaveBeenCalled();
-				} );
-			} );
-
-			describe( 'When the error is about something else', () => {
-				it( 'Should return a 400 with a message', async () => {
-
-					req.formError = new Error( 'The error is something else' );
-
-					await method( req, res );
-
-					expect( res.status ).toHaveBeenCalledWith( 400 );
-					expect( res.json ).toHaveBeenCalledWith( { message: 'A system error has occured, so the file has not been uploaded. Try again.' } );
-					expect( reporter.captureException ).toHaveBeenCalledWith( req.formError );
-				} );
-			} );
-		} );
-
-		describe( 'When there is not a formError', () => {
-			describe( 'When there is not a document', () => {
-				it( 'Should return a 400 with an error message', async () => {
-
-					await method( req, res );
-
-					expect( res.status ).toHaveBeenCalledWith( 400 );
-					expect( res.json ).toHaveBeenCalledWith( { message: 'Unsupported file format. The following file formats are accepted .jpg, .csv' } );
-					expect( reporter.message ).toHaveBeenCalledWith( 'info', 'Invalid document type: undefined', { size: undefined, name: undefined } );
-				} );
-			} );
-
-			describe( 'When there is a document', () => {
-
-				let doc;
-
-				beforeEach( () => {
-
-					doc = { type: 'text/plain', size: 10, name: 'test-1.txt' };
-					req.body.document = doc;
-				} );
-
-				describe( 'When the document is invalid', () => {
-					it( 'Should return 400 with an error message', async () => {
-
-						validators.isValidFile.and.callFake( () => false );
-
-						await method( req, res );
-
-						expect( res.status ).toHaveBeenCalledWith( 400 );
-						expect( res.json ).toHaveBeenCalledWith( { message: 'Unsupported file format. The following file formats are accepted .jpg, .csv' } );
-						expect( reporter.message ).toHaveBeenCalledWith( 'info', `Invalid document type: ${ doc.type }`, { size: doc.size, name: doc.name } );
-					} );
-				} );
-
-				describe( 'When the document is valid', () => {
-
-					beforeEach( () => {
-
-						validators.isValidFile.and.callFake( () => true );
-					} );
-
-					describe( 'When uploadDocument returns an error', () => {
-						it( 'Should return a 500', async () => {
-
-							const err = new Error( 'uploadDocument error' );
-
-							uploadDocument.and.callFake( () => Promise.reject( err ) );
-
-							await method( req, res );
-
-							expect( res.status ).toHaveBeenCalledWith( 500 );
-							expect( res.json ).toHaveBeenCalledWith( { message: 'A system error has occured, so the file has not been uploaded. Try again.' } );
-							expect( reporter.captureException ).toHaveBeenCalledWith( err );
-						} );
-					} );
-
-					describe( 'When uploadDocument returns a documentId', () => {
-
-						let documentId;
-
-						beforeEach( () => {
-
-							documentId = uuid();
-							uploadDocument.and.callFake( () => documentId );
-						} );
-
-						describe( 'When the document does not pass virus scanning', () => {
-							it( 'Should return a 401', async () => {
-
-								backend.documents.getScanStatus.and.callFake( () => Promise.resolve( { passed: false } ) );
-
-								await method( req, res );
-
-								expect( res.status ).toHaveBeenCalledWith( 401 );
-								expect( res.json ).toHaveBeenCalledWith( { message: 'This file may be infected with a virus and will not be accepted.' } );
-							} );
-						} );
-
-						describe( 'When the document passes virus scanning', () => {
-							it( 'Should return the document details and add the document to the session', async () => {
-
-								backend.documents.getScanStatus.and.callFake( () => Promise.resolve( { passed: true } ) );
-
-								await method( req, res );
-
-								expect( res.json ).toHaveBeenCalledWith( {
-									documentId,
-									file: { name: doc.name, size: '10 Bytes' }
-								} );
-
-								passedCb( documentId, doc );
-							} );
-						} );
-					} );
-				} );
-			} );
-		} );
-	}
-
-	describe( 'With a missing mime type map', () => {
-		it( 'Should report the error', () => {
-
-			config.files.types.push( 'fake/mime' );
-
-			controller = proxyquire( modulePath, {
-				'../../../config': config,
-				'../../../lib/backend-service': backend,
-				'../../../lib/urls': urls,
-				'../../../lib/Form': Form,
-				'../../../lib/FormProcessor': FormProcessor,
-				'../../../lib/validators': validators,
-				'../view-models/detail': barrierDetailViewModel,
-				'../view-models/interactions': interactionsViewModel,
-				'../../../lib/upload-document': uploadDocument,
-				'../../../lib/reporter': reporter,
-			} );
-
-			expect( reporter.message ).toHaveBeenCalledWith( 'info', 'No file extension mapping found for valid type: fake/mime'  );
-		} );
-	} );
 
 	describe( 'list', () => {
 
@@ -523,7 +366,7 @@ describe( 'Barrier interactions controller', () => {
 
 						expect( validator( file ) ).toEqual( true );
 						expect( validators.isValidFile ).toHaveBeenCalledWith( file );
-						expect( reporter.message ).not.toHaveBeenCalled();
+						expect( documentControllers.reportInvalidFile ).not.toHaveBeenCalled();
 					} );
 				} );
 
@@ -534,7 +377,7 @@ describe( 'Barrier interactions controller', () => {
 
 						expect( validator( file ) ).toEqual( false );
 						expect( validators.isValidFile ).toHaveBeenCalledWith( file );
-						expect( reporter.message ).toHaveBeenCalledWith( 'info', 'Invalid document type: ' + file.type, { size: file.size, name: file.name } );
+						expect( documentControllers.reportInvalidFile ).toHaveBeenCalledWith( file );
 					} );
 				} );
 			} );
@@ -745,7 +588,7 @@ describe( 'Barrier interactions controller', () => {
 
 								await config.saveFormData( formValues );
 
-								expect( next ).toHaveBeenCalledWith( new Error( 'This file may be infected with a virus and will not be accepted.' ) );
+								expect( next ).toHaveBeenCalledWith( new Error( documentControllers.FILE_INFECTED_MESSAGE ) );
 							} );
 						} );
 					} );
@@ -1056,170 +899,66 @@ describe( 'Barrier interactions controller', () => {
 				req.params.id = documentId;
 			} );
 
-			describe( 'delete', () => {
+			describe( 'add', () => {
+				it( 'Uses the documentControllers and adds the document to the session', async () => {
 
-				afterEach( () => {
+					const document = { type: 'text/plain', size: 10, name: 'test-1.txt' };
 
-					expect( backend.documents.delete ).toHaveBeenCalledWith( req, documentId );
-				} );
+					req.body.document = document;
 
-				describe( 'When the backend returns an error', () => {
+					expect( controller.notes.documents.add ).toEqual( documentControllers.xhr.add.cb );
 
-					let err;
+					documentControllers.xhr.add.calls.argsFor( 1 )[ 0 ]( req, { ...document, id: documentId } );
 
-					beforeEach( () => {
-
-						err = new Error( 'A backend error' );
-						backend.documents.delete.and.callFake( () => Promise.reject( err ) );
-					} );
-
-					describe( 'When it is a POST', () => {
-						it( 'Should return a JSON error with status 500', async () => {
-
-							req.method = 'POST';
-
-							await controller.notes.documents.delete( req, res, next );
-
-							expect( res.status ).toHaveBeenCalledWith( 500 );
-							expect( res.json ).toHaveBeenCalledWith( { message: 'Error deleting file' } );
-							expect( reporter.captureException ).toHaveBeenCalledWith( err );
-						} );
-					} );
-
-					describe( 'When it is a GET', () => {
-						it( 'Should call next with the error', async () => {
-
-							await controller.notes.documents.delete( req, res, next );
-
-							expect( next ).toHaveBeenCalledWith( err );
-							expect( reporter.captureException ).not.toHaveBeenCalled();
-						} );
-					} );
-				} );
-
-				describe( 'When the backend returns a 200', () => {
-
-					beforeEach( () => {
-
-						backend.documents.delete.and.callFake( () => Promise.resolve( {
-							response: { isSuccess: true }
-						} ) );
-					} );
-
-					describe( 'When it is a POST', () => {
-
-						beforeEach( () => {
-
-							req.method = 'POST';
-						} );
-
-						describe( 'When there are not any documents in the session', () => {
-							it( 'Should return the response in JSON', async () => {
-
-								await controller.notes.documents.delete( req, res, next );
-
-								expect( res.json ).toHaveBeenCalledWith( {} );
-							} );
-						} );
-
-						describe( 'When there are documents in the session', () => {
-							it( 'Should remove the matching document and return a 200', async () => {
-
-								const nonMatchingDoc1 = { document: { id: uuid(), name: 'test1.txt'} };
-								const matchingDoc = { document: { id: documentId, name: 'match1.txt' } };
-
-								req.session.noteDocuments = { [noteId]: [ nonMatchingDoc1, matchingDoc ] };
-
-								await controller.notes.documents.delete( req, res, next );
-
-								expect( res.json ).toHaveBeenCalledWith( {} );
-								expect( req.session.noteDocuments[ noteId ] ).toEqual( [ nonMatchingDoc1 ] );
-							} );
-						} );
-					} );
-
-					describe( 'When it is a GET', () => {
-						it( 'Should retun a 302 to the edit note page', async () => {
-
-							const editResponse = '/edit-a-note';
-
-							urls.barriers.notes.edit.and.callFake( () => editResponse );
-
-							await controller.notes.documents.delete( req, res, next );
-
-							expect( res.redirect ).toHaveBeenCalledWith( editResponse );
-							expect( urls.barriers.notes.edit ).toHaveBeenCalledWith( barrierId, noteId );
-						} );
-					} );
-				} );
-
-				describe( 'When the backend returns a 500', () => {
-
-					beforeEach( () => {
-
-						backend.documents.delete.and.callFake( () => Promise.resolve( {
-							response: { isSuccess: false, statusCode: 500 }
-						} ) );
-					} );
-
-					describe( 'When it is a POST', () => {
-
-						beforeEach( () => {
-
-							req.method = 'POST';
-						} );
-
-						afterEach( () => {
-
-							expect( res.status ).toHaveBeenCalledWith( 500 );
-							expect( res.json ).toHaveBeenCalledWith( { message: 'Error deleting file' } );
-							expect( reporter.captureException ).toHaveBeenCalledWith( new Error( `Unable to delete document ${ documentId }, got 500 from backend` ) );
-						} );
-
-						describe( 'When there are not any documents in the session', () => {
-							it( 'Should return a 500 and report the error in JSON', async () => {
-
-								await controller.notes.documents.delete( req, res, next );
-							} );
-						} );
-
-						describe( 'When there are documents in the session', () => {
-							it( 'Should leave the matching document and return a 500', async () => {
-
-								const nonMatchingDoc1 = { noteId, document: { id: uuid(), name: 'test1.txt'} };
-								const matchingDoc = { noteId, document: { id: documentId, name: 'match1.txt' } };
-
-								req.session.noteDocuments = [ nonMatchingDoc1, matchingDoc ];
-
-								await controller.notes.documents.delete( req, res, next );
-
-								expect( req.session.noteDocuments ).toEqual( [ nonMatchingDoc1, matchingDoc ] );
-							} );
-						} );
-					} );
-
-					describe( 'When it is a GET', () => {
-						it( 'Should call next with the error', async () => {
-
-							await controller.notes.documents.delete( req, res, next );
-
-							expect( next ).toHaveBeenCalledWith( new Error( `Unable to delete document ${ documentId }, got 500 from backend` ) );
-						} );
-					} );
+					expect( req.session.noteDocuments ).toBeDefined();
+					expect( req.session.noteDocuments[ noteId ] ).toEqual( [{ document: {
+						...document,
+						id: documentId,
+					} }] );
 				} );
 			} );
 
-			describe( 'add', () => {
+			describe( 'delete', () => {
 
-				checkAddDocument( () => controller.notes.documents.add, ( documentId, doc ) => {
+				it( 'Uses the documentControllers', () => {
 
-					expect( req.session.noteDocuments[ noteId ] ).toEqual( [{
-						document: {
-							id: documentId,
-							size: '10 Bytes',
-							name: doc.name,
-						}
-					}] );
+					const editNoteUrlResponse = 'a/b/c';
+					urls.barriers.notes.edit.and.returnValue( editNoteUrlResponse );
+
+					expect( controller.notes.documents.delete ).toEqual( documentControllers.delete.cb );
+
+					const args = documentControllers.delete.calls.argsFor( 0 );
+
+					expect( typeof args[ 0 ] ).toEqual( 'function' );
+					expect( typeof args[ 1 ] ).toEqual( 'function' );
+					expect( typeof args[ 2 ] ).toEqual( 'function' );
+
+					expect( args[ 0 ]( req ) ).toEqual( documentId );
+					expect( args[ 1 ]( req ) ).toEqual( editNoteUrlResponse );
+					expect( urls.barriers.notes.edit ).toHaveBeenCalledWith( barrierId, noteId );
+				} );
+
+				describe( 'When there are not any documents in the session', () => {
+					it( 'Should return the response in JSON', async () => {
+
+						documentControllers.delete.calls.argsFor( 0 )[ 2 ]( req, documentId );
+
+						expect( req.session.noteDocuments ).not.toBeDefined();
+					} );
+				} );
+
+				describe( 'When there are documents in the session', () => {
+					it( 'Should remove the matching document', async () => {
+
+						const nonMatchingDoc1 = { document: { id: uuid(), name: 'test1.txt'} };
+						const matchingDoc = { document: { id: documentId, name: 'match1.txt' } };
+
+						req.session.noteDocuments = { [ noteId ]: [ nonMatchingDoc1, matchingDoc ] };
+
+						documentControllers.delete.calls.argsFor( 0 )[ 2 ]( req, documentId );
+
+						expect( req.session.noteDocuments[ noteId ] ).toEqual( [ nonMatchingDoc1 ] );
+					} );
 				} );
 			} );
 
@@ -1264,137 +1003,103 @@ describe( 'Barrier interactions controller', () => {
 	} );
 
 	describe( 'documents (AJAX)', () => {
+
+		let barrierId;
+		let documentId;
+
+		beforeEach( () => {
+
+			barrierId = uuid();
+			documentId = uuid();
+
+			req.uuid = barrierId;
+			req.params.id = documentId;
+		} );
+
 		describe( 'add', () => {
 
-			checkAddDocument( () => controller.documents.add, ( documentId, doc ) => {
+			describe( 'When there are not any documents in the session', () => {
+				it( 'Uses the documentControllers and adds the document to the session', async () => {
 
-				expect( req.session.barrierDocuments ).toEqual( [{
-					barrierId: req.uuid,
-					document: {
-						id: documentId,
-						size: '10 Bytes',
-						name: doc.name,
-					}
-				}] );
+					const existingItem = { barrierId: uuid(), document: { id: uuid() } };
+					const document = { type: 'text/plain', size: 10, name: 'test-1.txt' };
+
+					req.body.document = document;
+					req.session.barrierDocuments = [ existingItem ];
+
+					expect( controller.documents.add ).toEqual( documentControllers.xhr.add.cb );
+
+					documentControllers.xhr.add.calls.argsFor( 0 )[ 0 ]( req, { ...document, id: documentId } );
+
+					expect( req.session.barrierDocuments ).toEqual( [
+						existingItem,
+						{
+							barrierId,
+							document: {
+								...document,
+								id: documentId,
+							}
+						}
+					] );
+				} );
+			} );
+
+			describe( 'When there are documents in the session', () => {
+				it( 'Uses the documentControllers and adds the document to the session', async () => {
+
+					const document = { type: 'text/plain', size: 10, name: 'test-1.txt' };
+
+					req.body.document = document;
+
+					expect( controller.documents.add ).toEqual( documentControllers.xhr.add.cb );
+
+					documentControllers.xhr.add.calls.argsFor( 0 )[ 0 ]( req, { ...document, id: documentId } );
+
+					expect( req.session.barrierDocuments ).toEqual( [{
+						barrierId,
+						document: {
+							...document,
+							id: documentId,
+						}
+					}] );
+				} );
 			} );
 		} );
 
 		describe( 'delete', () => {
 
-			let barrierId;
-			let documentId;
+			it( 'Uses the documentControllers', () => {
 
-			beforeEach( () => {
-
-				barrierId = uuid();
-				documentId = uuid();
-
-				req.uuid = barrierId;
-				req.params.id = documentId;
+				expect( controller.documents.delete ).toEqual( documentControllers.xhr.delete.cb );
+				const args = documentControllers.xhr.delete.calls.argsFor( 0 );
+				expect( typeof args[ 0 ] ).toEqual( 'function' );
+				expect( typeof args[ 1 ] ).toEqual( 'function' );
+				expect( args[ 0 ]( req ) ).toEqual( documentId );
 			} );
 
-			describe( 'When the document id is invalid', () => {
-				it( 'Should return a 500 and report the error', async () => {
+			describe( 'When there are barrier documents in the session', () => {
+				it( 'Should remove the document from the session', () => {
 
-					validators.isUuid.and.callFake( () => false );
+					const nonMatchingDoc1 = { id: uuid(), name: 'test1.jpg' };
+					const matchingDoc = { id: documentId, name: 'match.txt' };
 
-					await controller.documents.delete( req, res );
+					req.session.barrierDocuments = [
+						{ barrierId, document: nonMatchingDoc1 },
+						{ barrierId, document: matchingDoc }
+					];
 
-					expect( res.status ).toHaveBeenCalledWith( 500 );
-					expect( res.json ).toHaveBeenCalledWith( {} );
-					expect( reporter.captureException ).toHaveBeenCalledWith( new Error( 'Invalid documentId' ) );
+					documentControllers.xhr.delete.calls.argsFor( 0 )[ 1 ]( req, documentId );
+
+					expect( req.session.barrierDocuments ).toEqual( [ { barrierId, document: nonMatchingDoc1 } ] );
 				} );
 			} );
 
-			describe( 'When the document id is valid', () => {
+			describe( 'When there are no documents in the session', () => {
+				it( 'Should not error and have no documents in the session', () => {
 
-				beforeEach( () => {
-					validators.isUuid.and.callFake( () => true );
-				} );
+					documentControllers.xhr.delete.calls.argsFor( 0 )[ 1 ]( req, documentId );
 
-				describe( 'When the backend delete rejects', () => {
-					it( 'Should return a 500 with the correct message', async () => {
-
-						const err = new Error( 'A backend fail' );
-
-						backend.documents.delete.and.callFake( () => Promise.reject( err ) );
-
-						await controller.documents.delete( req, res );
-
-						expect( res.status ).toHaveBeenCalledWith( 500 );
-						expect( res.json ).toHaveBeenCalledWith( {} );
-						expect( reporter.captureException ).toHaveBeenCalledWith( err );
-					} );
-				} );
-
-				describe( 'When the backend resolves', () => {
-					describe( 'When it is a 500', () => {
-						it( 'Should report the error', async() => {
-
-							backend.documents.delete.and.callFake( () => Promise.resolve( { response: { statusCode: 500 } } ) );
-
-							await controller.documents.delete( req, res );
-
-							expect( res.status ).toHaveBeenCalledWith( 500 );
-							expect( res.json ).toHaveBeenCalledWith( { message: 'A system error has occured, so the file has not been deleted. Try again.' } );
-							expect( reporter.captureException ).toHaveBeenCalledWith( new Error( `Unable to delete document ${ documentId }, got 500 from backend` ) );
-						} );
-					} );
-
-					function checkSuccess(){
-
-						afterEach( () => {
-
-							expect( res.status ).toHaveBeenCalledWith( 200 );
-							expect( res.json ).toHaveBeenCalledWith( {} );
-						} );
-
-						describe( 'When there are barrier documents in the session', () => {
-							it( 'Should remove the document from the session and return a 200', async() => {
-
-								const nonMatchingDoc1 = { id: uuid(), name: 'test1.jpg' };
-								const matchingDoc = { id: documentId, name: 'match.txt' };
-
-								req.session.barrierDocuments = [
-									{ barrierId, document: nonMatchingDoc1 },
-									{ barrierId, document: matchingDoc }
-								];
-
-								await controller.documents.delete( req, res );
-
-								expect( req.session.barrierDocuments ).toEqual( [ { barrierId, document: nonMatchingDoc1 } ] );
-							} );
-						} );
-
-						describe( 'When there are not documents in the session', () => {
-							it( 'Should not error and have no documents in the session', async () => {
-
-								await controller.documents.delete( req, res );
-
-								expect( req.session.barrierDocuments ).not.toBeDefined();
-							} );
-						} );
-					}
-
-					describe( 'When it is a 200', () => {
-
-						beforeEach( () => {
-
-							backend.documents.delete.and.callFake( () => Promise.resolve( { response: { isSuccess: true } } ) );
-						} );
-
-						checkSuccess();
-					} );
-
-					describe( 'When it is a 404', () => {
-
-						beforeEach( () => {
-
-							backend.documents.delete.and.callFake( () => Promise.resolve( { response: { statusCode: 404 } } ) );
-						} );
-
-						checkSuccess();
-					} );
+					expect( req.session.barrierDocuments ).not.toBeDefined();
 				} );
 			} );
 		} );

--- a/src/app/sub-apps/barriers/controllers/interactions.spec.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.spec.js
@@ -54,7 +54,10 @@ describe( 'Barrier interactions controller', () => {
 					save: jasmine.createSpy( 'backend.barriers.notes.save' ),
 					update: jasmine.createSpy( 'backend.barriers.notes.update' ),
 					delete: jasmine.createSpy( 'backend.barriers.notes.delete' ),
-				}
+				},
+				assessment: {
+					getHistory: jasmine.createSpy( 'backend.barriers.assessment.getHistory' ),
+				},
 			}
 		};
 
@@ -137,11 +140,16 @@ describe( 'Barrier interactions controller', () => {
 			response: { isSuccess: true },
 			body: getFakeData( '/backend/barriers/history' )
 		};
+		const assessmentHistoryResponse = {
+			response: { isSuccess: true },
+			body: getFakeData( '/backend/barriers/assessment_history' ),
+		};
 
-		backend.barriers.getInteractions.and.callFake( () => Promise.resolve( interactionsResponse ) );
-		backend.barriers.getHistory.and.callFake( () => Promise.resolve( historyResponse ) );
+		backend.barriers.getInteractions.and.returnValue( Promise.resolve( interactionsResponse ) );
+		backend.barriers.getHistory.and.returnValue( Promise.resolve( historyResponse ) );
+		backend.barriers.assessment.getHistory.and.returnValue( Promise.resolve( assessmentHistoryResponse ) );
 
-		return { interactionsResponse, historyResponse };
+		return { interactionsResponse, historyResponse, assessmentHistoryResponse };
 	}
 
 	function returnViewModels(){
@@ -157,8 +165,10 @@ describe( 'Barrier interactions controller', () => {
 
 	async function check( controller, addCompany, data = {} ){
 
-		const { interactionsResponse, historyResponse } = returnSuccessResponses();
+		const { interactionsResponse, historyResponse, assessmentHistoryResponse } = returnSuccessResponses();
 		const { barrierDetailViewModelResponse, interactionsViewModelResponse } = returnViewModels();
+
+		req.barrier.has_assessment = true;
 
 		await controller( req, res, next );
 
@@ -168,7 +178,8 @@ describe( 'Barrier interactions controller', () => {
 		expect( barrierDetailViewModel ).toHaveBeenCalledWith( req.barrier, addCompany );
 		expect( interactionsViewModel ).toHaveBeenCalledWith( {
 			interactions: interactionsResponse.body,
-			history: historyResponse.body
+			history: historyResponse.body,
+			assessmentHistory: assessmentHistoryResponse,
 		}, undefined );
 
 		expect( res.render ).toHaveBeenCalledWith( 'barriers/views/detail',  {
@@ -446,7 +457,8 @@ describe( 'Barrier interactions controller', () => {
 						expect( barrierDetailViewModel ).toHaveBeenCalledWith( req.barrier, false );
 						expect( interactionsViewModel ).toHaveBeenCalledWith( {
 							interactions: interactionsResponse.body,
-							history: historyResponse.body
+							history: historyResponse.body,
+							assessmentHistory: undefined,
 						}, undefined );
 
 						config.saveFormData( formValues );
@@ -678,7 +690,8 @@ describe( 'Barrier interactions controller', () => {
 					expect( barrierDetailViewModel ).toHaveBeenCalledWith( req.barrier, req.query.addCompany);
 					expect( interactionsViewModel ).toHaveBeenCalledWith( {
 						interactions: interactionsResponse.body,
-						history: historyResponse.body
+						history: historyResponse.body,
+						assessmentHistory: undefined,
 					}, editId );
 
 					config.saveFormData( formValues );

--- a/src/app/sub-apps/barriers/controllers/team.js
+++ b/src/app/sub-apps/barriers/controllers/team.js
@@ -114,7 +114,6 @@ module.exports = {
 			if( !form.hasErrors() ){
 
 				const { query } = form.getValues();
-
 				try {
 
 					const { response, body } = await sso.users.search( query );

--- a/src/app/sub-apps/barriers/middleware/barrier-assessment.js
+++ b/src/app/sub-apps/barriers/middleware/barrier-assessment.js
@@ -1,0 +1,28 @@
+const backend = require( '../../../lib/backend-service' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
+
+module.exports = async ( req, res, next ) => {
+
+	try {
+
+		const { response, body } = await backend.barriers.assessment.get( req, req.barrier.id );
+
+		if( response.isSuccess ){
+
+			req.assessment = body;
+			next();
+
+		} else if( response.statusCode === 404 ){
+
+			next();
+
+		} else {
+
+			throw new HttpResponseError( 'Unable to get barrier assessment', response, body );
+		}
+
+	} catch( e ){
+
+		next( e );
+	}
+};

--- a/src/app/sub-apps/barriers/middleware/barrier-assessment.spec.js
+++ b/src/app/sub-apps/barriers/middleware/barrier-assessment.spec.js
@@ -1,0 +1,89 @@
+const proxyquire = require( 'proxyquire' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
+
+const { mocks, getFakeData } = jasmine.helpers;
+
+const modulePath = './barrier-assessment';
+
+describe( 'Barrier assessment middleware', () => {
+
+	let req;
+	let res;
+	let next;
+	let middleware;
+	let backend;
+
+	beforeEach( () => {
+
+		({ req, res, next } = mocks.middleware());
+
+		backend = {
+			barriers: {
+				assessment: {
+					get: jasmine.createSpy( 'backend.barriers.assessment.get' ),
+				}
+			}
+		};
+
+		req.barrier = getFakeData( '/backend/barriers/barrier' );
+
+		middleware = proxyquire( modulePath, {
+			'../../../lib/backend-service': backend,
+		} );
+	} );
+
+	afterEach( () => {
+
+		expect( backend.barriers.assessment.get ).toHaveBeenCalledWith( req, req.barrier.id );
+	} );
+
+	describe( 'When the backend call rejects', () => {
+		it( 'Calls next with an error', async () => {
+
+			const err = new Error( 'A backend assessment issue' );
+
+			backend.barriers.assessment.get.and.returnValue( Promise.reject( err ) );
+			await middleware( req, res, next );
+
+			expect( next ).toHaveBeenCalledWith( err );
+		} );
+	} );
+
+	describe( 'When the backend resolves with a 500', () => {
+		it( 'Calls next with an error', async () => {
+
+			backend.barriers.assessment.get.and.returnValue( mocks.request( 500 ) );
+
+			await middleware( req, res, next );
+
+			expect( next ).toHaveBeenCalled();
+			expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
+		} );
+	} );
+
+	describe( 'When the backend resolves with a 404', () => {
+		it( 'Calls next', async () => {
+
+			backend.barriers.assessment.get.and.returnValue( mocks.request( 404 ) );
+
+			await middleware( req, res, next );
+
+			expect( req.assessment ).not.toBeDefined();
+			expect( next ).toHaveBeenCalledWith();
+		} );
+	} );
+
+	describe( 'When the backend resolves with a 200', () => {
+		it( 'Calls next with the assessment data', async () => {
+
+			const assessment = getFakeData( '/backend/barriers/assessment' );
+
+			backend.barriers.assessment.get.and.returnValue( mocks.request( 200, assessment ) );
+
+			await middleware( req, res, next );
+
+			expect( req.assessment ).toEqual( assessment );
+			expect( next ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/src/app/sub-apps/barriers/middleware/barrier-session.js
+++ b/src/app/sub-apps/barriers/middleware/barrier-session.js
@@ -47,8 +47,12 @@ module.exports = ( req, res, next ) => {
 			...methods,
 			types: createMethods( 'types' ),
 			sectors: {
-				all: createMethods( 'all'),
-				list: createMethods('list')
+				all: createMethods( 'all' ),
+				list: createMethods( 'list' )
+			},
+			documents: {
+				//barrier: createMethods( 'barrier-documents' ),
+				assessment: createMethods( 'assessment-documents' ),
 			},
 		};
 

--- a/src/app/sub-apps/barriers/routes.js
+++ b/src/app/sub-apps/barriers/routes.js
@@ -115,8 +115,9 @@ module.exports = ( express, app ) => {
 	app.post( '/:barrierId/team/delete/:memberId', barrierTeam, controller.team.delete );
 
 	app.get( '/:barrierId/assessment/', barrierAssessment, controller.assessment.detail );
-	app.get( '/:barrierId/assessment/economic/', barrierSession, barrierAssessment, controller.assessment.economic );
-	app.post( '/:barrierId/assessment/economic/', barrierSession, fileUpload, controller.assessment.economic );
+	app.get( '/:barrierId/assessment/economic/', barrierSession, barrierAssessment, controller.assessment.economic.list );
+	app.post( '/:barrierId/assessment/economic/', barrierSession, fileUpload, controller.assessment.economic.list );
+	app.get( '/:barrierId/assessment/economic/new/', barrierSession, controller.assessment.economic.new );
 	app.get( '/:barrierId/assessment/economy-value/', barrierAssessment, controller.assessment.economyValue );
 	app.post( '/:barrierId/assessment/economy-value/', controller.assessment.economyValue );
 	app.get( '/:barrierId/assessment/market-size/', barrierAssessment, controller.assessment.marketSize );

--- a/src/app/sub-apps/barriers/routes.js
+++ b/src/app/sub-apps/barriers/routes.js
@@ -10,6 +10,7 @@ const barrierTypeCategoryParam = require( './middleware/params/barrier-type-cate
 const companyIdParam = require( './middleware/params/company-id' );
 const uuidParam = require( '../../middleware/params/uuid' );
 const barrierTeam = require( './middleware/barrier-team' );
+const barrierAssessment = require( './middleware/barrier-assessment' );
 
 const csrfProtection = csurf();
 
@@ -113,20 +114,21 @@ module.exports = ( express, app ) => {
 	app.get( '/:barrierId/team/delete/:memberId', barrierTeam, controller.team.delete );
 	app.post( '/:barrierId/team/delete/:memberId', barrierTeam, controller.team.delete );
 
-	app.get( '/:barrierId/assessment/', controller.assessment.detail );
-	app.get( '/:barrierId/assessment/economic/', barrierSession, controller.assessment.economic );
+	app.get( '/:barrierId/assessment/', barrierAssessment, controller.assessment.detail );
+	app.get( '/:barrierId/assessment/economic/', barrierSession, barrierAssessment, controller.assessment.economic );
 	app.post( '/:barrierId/assessment/economic/', barrierSession, fileUpload, controller.assessment.economic );
-	app.get( '/:barrierId/assessment/economy-value/', controller.assessment.economyValue );
+	app.get( '/:barrierId/assessment/economy-value/', barrierAssessment, controller.assessment.economyValue );
 	app.post( '/:barrierId/assessment/economy-value/', controller.assessment.economyValue );
-	app.get( '/:barrierId/assessment/market-size/', controller.assessment.marketSize );
+	app.get( '/:barrierId/assessment/market-size/', barrierAssessment, controller.assessment.marketSize );
 	app.post( '/:barrierId/assessment/market-size/', controller.assessment.marketSize );
-	app.get( '/:barrierId/assessment/export-value/', controller.assessment.exportValue );
+	app.get( '/:barrierId/assessment/export-value/', barrierAssessment, controller.assessment.exportValue );
 	app.post( '/:barrierId/assessment/export-value/', controller.assessment.exportValue );
-	app.get( '/:barrierId/assessment/commercial-value/', controller.assessment.commercialValue );
+	app.get( '/:barrierId/assessment/commercial-value/', barrierAssessment, controller.assessment.commercialValue );
 	app.post( '/:barrierId/assessment/commercial-value/', controller.assessment.commercialValue );
 
 	app.post( '/:uuid/assessment/documents/add/', barrierSession, fileUpload, controller.assessment.documents.add );
 	app.get( '/:uuid/assessment/documents/cancel/', barrierSession, controller.assessment.documents.cancel );
+	app.get( '/:uuid/assessment/documents/:id/delete/', barrierSession, controller.assessment.documents.delete );
 	app.post( '/:uuid/assessment/documents/:id/delete/', barrierSession, controller.assessment.documents.delete );
 	return app;
 };

--- a/src/app/sub-apps/barriers/routes.js
+++ b/src/app/sub-apps/barriers/routes.js
@@ -113,5 +113,16 @@ module.exports = ( express, app ) => {
 	app.get( '/:barrierId/team/delete/:memberId', barrierTeam, controller.team.delete );
 	app.post( '/:barrierId/team/delete/:memberId', barrierTeam, controller.team.delete );
 
+	app.get( '/:barrierId/assessment/', controller.assessment.list );
+	app.get( '/:barrierId/assessment/economic/', controller.assessment.economic );
+	app.post( '/:barrierId/assessment/economic/', controller.assessment.economic );
+	app.get( '/:barrierId/assessment/economy-value/', controller.assessment.economyValue );
+	app.post( '/:barrierId/assessment/economy-value/', controller.assessment.economyValue );
+	app.get( '/:barrierId/assessment/market-size/', controller.assessment.marketSize );
+	app.post( '/:barrierId/assessment/market-size/', controller.assessment.marketSize );
+	app.get( '/:barrierId/assessment/export-value/', controller.assessment.exportValue );
+	app.post( '/:barrierId/assessment/export-value/', controller.assessment.exportValue );
+	app.get( '/:barrierId/assessment/commercial-value/', controller.assessment.commercialValue );
+	app.post( '/:barrierId/assessment/commercial-value/', controller.assessment.commercialValue );
 	return app;
 };

--- a/src/app/sub-apps/barriers/routes.js
+++ b/src/app/sub-apps/barriers/routes.js
@@ -113,9 +113,9 @@ module.exports = ( express, app ) => {
 	app.get( '/:barrierId/team/delete/:memberId', barrierTeam, controller.team.delete );
 	app.post( '/:barrierId/team/delete/:memberId', barrierTeam, controller.team.delete );
 
-	app.get( '/:barrierId/assessment/', controller.assessment.list );
-	app.get( '/:barrierId/assessment/economic/', controller.assessment.economic );
-	app.post( '/:barrierId/assessment/economic/', controller.assessment.economic );
+	app.get( '/:barrierId/assessment/', controller.assessment.detail );
+	app.get( '/:barrierId/assessment/economic/', barrierSession, controller.assessment.economic );
+	app.post( '/:barrierId/assessment/economic/', barrierSession, fileUpload, controller.assessment.economic );
 	app.get( '/:barrierId/assessment/economy-value/', controller.assessment.economyValue );
 	app.post( '/:barrierId/assessment/economy-value/', controller.assessment.economyValue );
 	app.get( '/:barrierId/assessment/market-size/', controller.assessment.marketSize );
@@ -124,5 +124,9 @@ module.exports = ( express, app ) => {
 	app.post( '/:barrierId/assessment/export-value/', controller.assessment.exportValue );
 	app.get( '/:barrierId/assessment/commercial-value/', controller.assessment.commercialValue );
 	app.post( '/:barrierId/assessment/commercial-value/', controller.assessment.commercialValue );
+
+	app.post( '/:uuid/assessment/documents/add/', barrierSession, fileUpload, controller.assessment.documents.add );
+	app.get( '/:uuid/assessment/documents/cancel/', barrierSession, controller.assessment.documents.cancel );
+	app.post( '/:uuid/assessment/documents/:id/delete/', barrierSession, controller.assessment.documents.delete );
 	return app;
 };

--- a/src/app/sub-apps/barriers/view-models/assessment/economic.js
+++ b/src/app/sub-apps/barriers/view-models/assessment/economic.js
@@ -1,0 +1,23 @@
+const { documents: documentUrls } = require( '../../../../lib/urls' ).barriers.assessment;
+
+
+module.exports = function( barrierId, documents, templateValues ){
+
+	const values = {
+		...templateValues,
+		xhr: {
+			upload: documentUrls.add( barrierId ),
+			delete: documentUrls.delete( barrierId, ':uuid' ),
+		},
+	};
+
+	if( documents ){
+
+		values.documents = documents.map( ( document ) => ({
+			...document,
+			deleteUrl: documentUrls.delete( barrierId, document.id )
+		}) );
+	}
+
+	return values;
+};

--- a/src/app/sub-apps/barriers/view-models/assessment/economic.js
+++ b/src/app/sub-apps/barriers/view-models/assessment/economic.js
@@ -1,7 +1,7 @@
 const { documents: documentUrls } = require( '../../../../lib/urls' ).barriers.assessment;
 
 
-module.exports = function( barrierId, documents, templateValues ){
+module.exports = function( barrierId, sessionDocuments, templateValues ){
 
 	const values = {
 		...templateValues,
@@ -11,9 +11,9 @@ module.exports = function( barrierId, documents, templateValues ){
 		},
 	};
 
-	if( documents ){
+	if( sessionDocuments ){
 
-		values.documents = documents.map( ( document ) => ({
+		values.documents = sessionDocuments.map( ( document ) => ({
 			...document,
 			deleteUrl: documentUrls.delete( barrierId, document.id )
 		}) );

--- a/src/app/sub-apps/barriers/view-models/assessment/economic.spec.js
+++ b/src/app/sub-apps/barriers/view-models/assessment/economic.spec.js
@@ -1,0 +1,60 @@
+const proxyquire = require( 'proxyquire' );
+const faker = require( 'faker' );
+const modulePath = './economic';
+
+function createDoc(){
+
+	return {
+		id: faker.random.uuid(),
+		name: faker.lorem.words( 2 ),
+		size: faker.random.number(),
+	};
+}
+
+describe( 'Economic assessemnt view model', () => {
+	it( 'Adds the data to the model', () => {
+
+		const documentAddUrl = 'add/x/y/z';
+		const documentDeleteUrl = 'delete/x/y/z';
+		const urls = {
+			barriers: {
+				assessment: {
+					documents: {
+						add: jasmine.createSpy( 'urs.barriers.assessment.documents.add' ).and.returnValue( documentAddUrl ),
+						delete: jasmine.createSpy( 'urs.barriers.assessment.documents.delete' ).and.returnValue( documentDeleteUrl )
+					},
+				}
+			}
+		};
+
+		const viewModel = proxyquire( modulePath, {
+			'../../../../lib/urls': urls,
+		} );
+
+		const barrierId = faker.random.uuid();
+		const documents = [
+			createDoc(),
+			createDoc(),
+		];
+		const templateValues = { a: 1, b: 2 };
+
+		const data = viewModel( barrierId, documents, templateValues );
+
+		expect( data ).toEqual( {
+			...templateValues,
+			xhr: {
+				upload: documentAddUrl,
+				delete: documentDeleteUrl,
+			},
+			documents: documents.map( ( doc ) => ({
+				...doc,
+				deleteUrl: documentDeleteUrl,
+			}) ),
+		} );
+
+		expect( urls.barriers.assessment.documents.add ).toHaveBeenCalledWith( barrierId );
+		expect( urls.barriers.assessment.documents.delete ).toHaveBeenCalledWith( barrierId, ':uuid' );
+		expect( urls.barriers.assessment.documents.delete ).toHaveBeenCalledWith( barrierId, documents[ 0 ].id );
+		expect( urls.barriers.assessment.documents.delete ).toHaveBeenCalledWith( barrierId, documents[ 1 ].id );
+	} );
+} );

--- a/src/app/sub-apps/barriers/view-models/interactions.js
+++ b/src/app/sub-apps/barriers/view-models/interactions.js
@@ -125,10 +125,34 @@ function getHistory( items ){
 	return history;
 }
 
-module.exports = function ( responses, editId ){
+function getAssessmentHistory( items ){
+
+	const history = [];
+
+	for( const item of items ){
+
+		history.push( {
+			isAssessment: true,
+			isEdit: ( item.old_value !== null ),
+			name: metadata.barrier.assessment.fieldNames[ item.field ],
+			date: item.date,
+			user: item.user,
+		} );
+	}
+
+	return history;
+}
+
+module.exports = function( responses, editId ){
 
 	const notes = getNotes( responses.interactions.results, editId );
 	const history = getHistory( responses.history.history );
+	let items = notes.concat( history );
 
-	return notes.concat( history ).sort( sortByDateDescending );
+	if( responses.assessmentHistory ){
+
+		items = items.concat( getAssessmentHistory( responses.assessmentHistory.body.history ) );
+	}
+
+	return items.sort( sortByDateDescending );
 };

--- a/src/app/sub-apps/barriers/view-models/interactions.spec.js
+++ b/src/app/sub-apps/barriers/view-models/interactions.spec.js
@@ -82,23 +82,38 @@ describe( 'Interactions view model', () => {
 		};
 	}
 
+	function createAssessment( item ){
+		return {
+			isAssessment: true,
+			isEdit: ( item.old_value !== null ),
+			name: metadata.barrier.assessment.fieldNames[ item.field ],
+			date: item.date,
+			user: item.user,
+		};
+	}
+
 	it( 'Should combine the results and sort them', () => {
 
 		const interactionsResults = getFakeData( '/backend/barriers/interactions-ordered' ).results;
 		const historyResults = getFakeData( '/backend/barriers/history' ).history;
+		const assessmentHistoryResults = getFakeData( '/backend/barriers/assessment_history' ).history;
 
 		const output = viewModel( {
 			interactions: getFakeData( '/backend/barriers/interactions-ordered' ),
-			history: getFakeData( '/backend/barriers/history' )
+			history: getFakeData( '/backend/barriers/history' ),
+			assessmentHistory: { body: getFakeData( '/backend/barriers/assessment_history' ) },
 		}, String( interactionsResults[ 3 ].id ) );
 
 		expect( output ).toEqual( [
+			createAssessment( assessmentHistoryResults[ 1 ] ),
+			createAssessment( assessmentHistoryResults[ 0 ] ),
 			createNote( interactionsResults[ 3 ], true ),
 			createNote( interactionsResults[ 4 ] ),
 			createNote( interactionsResults[ 2 ] ),
 			createStatus( historyResults[ 2 ], RESOLVED, OPEN, false, true ),
 			createNote( interactionsResults[ 0 ] ),
 			createStatus( historyResults[ 4 ], OPEN, PAUSED, false, false ),
+			createAssessment( assessmentHistoryResults[ 2 ] ),
 			createPriority( historyResults[ 6 ] ),
 			createStatus( historyResults[ 3 ], OPEN, RESOLVED, true, false ),
 			createPriority( historyResults[ 5 ] ),

--- a/src/app/sub-apps/barriers/views/assessment/commercial-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/commercial-value.njk
@@ -1,0 +1,35 @@
+{% from 'app-components/currency-input.njk' import currencyInput %}
+{% from 'app-components/heading.njk' import heading %}
+
+{% extends 'layout.njk' %}
+
+{% block page_title %}{{ super() }} - Barrier Assessment - Commercial Value{% endblock %}
+
+{% block page_content %}
+
+	{{ heading({
+		back: { href: urls.barriers.assessment.detail( barrier.id ) },
+		caption: barrier.barrier_title,
+		text: 'Commercial Value',
+		errors: errors
+	}) }}
+
+	<form action="{{ urls.barriers.assessment.commercialValue( barrier.id ) }}" method="POST" class="restrict-width">
+		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+		{{ currencyInput( {
+
+			label: {
+				text: 'What is the value of the barrier to the affected business(es) per year?',
+				classes: 'govuk-label--s'
+			},
+			id: 'value',
+			name: 'value',
+			classes: 'govuk-input--currency',
+			value: value,
+			errorMessage: errors | errorForName( 'value' )
+		} ) }}
+
+		<input type="submit" value="Save and exit to barrier" class="govuk-button">
+	</form>
+{% endblock %}

--- a/src/app/sub-apps/barriers/views/assessment/commercial-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/commercial-value.njk
@@ -3,14 +3,14 @@
 
 {% extends 'layout.njk' %}
 
-{% block page_title %}{{ super() }} - Barrier Assessment - Commercial Value{% endblock %}
+{% block page_title %}{{ super() }} - Barrier Assessment - Commercial value{% endblock %}
 
 {% block page_content %}
 
 	{{ heading({
 		back: { href: urls.barriers.assessment.detail( barrier.id ) },
 		caption: barrier.barrier_title,
-		text: 'Commercial Value',
+		text: 'Commercial value',
 		errors: errors
 	}) }}
 
@@ -20,8 +20,11 @@
 		{{ currencyInput( {
 
 			label: {
-				text: 'What is the value of the barrier to the affected business(es) per year?',
+				text: 'What is the value of the barrier to the affected business(es)?',
 				classes: 'govuk-label--s'
+			},
+			hint: {
+				text: 'The value of the barrier to the affected business(es) in GBP per year.'
 			},
 			id: 'value',
 			name: 'value',

--- a/src/app/sub-apps/barriers/views/assessment/commercial-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/commercial-value.njk
@@ -29,7 +29,7 @@
 			id: 'value',
 			name: 'value',
 			classes: 'govuk-input--currency',
-			value: value,
+			value: value | formatNumber,
 			errorMessage: errors | errorForName( 'value' )
 		} ) }}
 

--- a/src/app/sub-apps/barriers/views/assessment/detail.njk
+++ b/src/app/sub-apps/barriers/views/assessment/detail.njk
@@ -66,16 +66,29 @@
 			<h2 class="assessment-item__heading">Economic assessment</h2>
 
 			<h3 class="assessment-item__sub-heading">Impact</h3>
-			<ol class="barrier-impact-scale">
-				{% for item in impactScale %}
-					<li class="barrier-impact-scale__item {{- ' barrier-impact-scale__item--active' if item.isActive }}">
-						{{ item.text }}
-					</li>
-				{% endfor %}
-			</ol>
+			<span class="barrier-impact-value">
+				{{ impact.text }}
+			</span>
 
 			<h3 class="assessment-item__sub-heading">Assessment explanation</h3>
 			<p class="assessment-item__value">{{ assessment.explanation | nl2br | safe }}</p>
+
+			{% if documents and documents.length %}
+
+				<h3 class="assessment-item__sub-heading">Supporting documents</h3>
+				<ul class="document-list document-list--assessment">
+					{% for document in documents %}
+						<li class="document-list__item">
+						{% if document.canDownload %}
+							<a href="{{ urls.documents.download( document.id ) }}">{{ document.name }}</a>
+						{% else %}
+							{{ document.name }}
+						{% endif %}
+						- {{ document.size }}
+						</li>
+					{% endfor %}
+				</ul>
+			{% endif %}
 
 			<h3 class="assessment-item__sub-heading">Inital assessment made by</h3>
 			<p class="assessment-item__value">{{ assessment.created_by.name }}</p>

--- a/src/app/sub-apps/barriers/views/assessment/detail.njk
+++ b/src/app/sub-apps/barriers/views/assessment/detail.njk
@@ -60,7 +60,7 @@
 
 	{% endmacro %}
 
-	{% if assessment %}
+	{% if assessment and assessment.explanation and assessment.impact %}
 
 		<div class="assessment-item">
 			<h2 class="assessment-item__heading">Economic assessment</h2>

--- a/src/app/sub-apps/barriers/views/assessment/detail.njk
+++ b/src/app/sub-apps/barriers/views/assessment/detail.njk
@@ -1,0 +1,144 @@
+{% from "components/inset-text/macro.njk" import govukInsetText %}
+{% from 'app-components/barrier-summary.njk' import barrierSummary %}
+{% from 'app-components/barrier-tabs.njk' import barrierTabs %}
+
+{% extends 'layout.njk' %}
+
+{% block page_title %}{{ super() }} - Barrier Assessment{% endblock %}
+
+{% block masthead %}
+	<div class="ma-masthead">
+		{{ barrierSummary( barrier ) }}
+	</div>
+{% endblock %}
+
+{% block body_script %}
+	{{ super() }}
+	<script>
+		if( ma.components.ToggleLinks ){
+			new ma.components.ToggleLinks( {
+				text: 'Update the barrier',
+				linkClass: 'js-barrier-summary-link'
+			} );
+		}
+	</script>
+{% endblock %}
+
+{% block page_content %}
+
+	{{ barrierTabs( barrier.id, 'assessment' ) }}
+
+	{% macro assessmentItem( params ) %}
+
+		<div class="assessment-item">
+
+			<h2 class="assessment-item__heading">{{ params.heading }}</h2>
+
+				{% if params.value %}
+
+					<p class="assessment-item__value">
+						&pound; {{ params.value }}
+					</p>
+					<a class="assessment-item__edit" href="{{ params.link.href }}">Edit</a>
+
+				{% else %}
+
+					<div class="assessment-item-content">
+						<a class="assessment-item-content__link" href="{{ params.link.href }}">{{ params.link.text }}</a>
+						<p class="assessment-item-content__hint">{{ params.hint }}</p>
+
+						{% if params.analyst %}
+							{{ govukInsetText({
+								text: 'To be completed by the Market Access Analysts',
+								classes: 'assessment-item-content__restriction'
+							}) }}
+						{% endif %}
+					</div>
+
+				{% endif %}
+		</div>
+
+	{% endmacro %}
+
+	{% if assessment %}
+
+		<div class="assessment-item">
+			<h2 class="assessment-item__heading">Economic assessment</h2>
+
+			<h3 class="assessment-item__sub-heading">Impact</h3>
+			<ol class="barrier-impact-scale">
+				{% for item in impactScale %}
+					<li class="barrier-impact-scale__item {{- ' barrier-impact-scale__item--active' if item.isActive }}">
+						{{ item.text }}
+					</li>
+				{% endfor %}
+			</ol>
+
+			<h3 class="assessment-item__sub-heading">Assessment explanation</h3>
+			<p class="assessment-item__value">{{ assessment.explanation | nl2br | safe }}</p>
+
+			<h3 class="assessment-item__sub-heading">Inital assessment made by</h3>
+			<p class="assessment-item__value">{{ assessment.created_by.name }}</p>
+
+			<a class="assessment-item__edit" href="{{ urls.barriers.assessment.economic( barrier.id ) }}">Edit</a>
+		</div>
+
+	{% else %}
+
+		{{ assessmentItem({
+			heading: 'Economic assessment',
+			link: {
+				text: 'Add economic assessment',
+				href: urls.barriers.assessment.economic( barrier.id )
+			},
+			hint: 'The assessed economic importance of resolving this barrier relative to others in the same country.',
+			analyst: true
+		}) }}
+
+	{% endif %}
+
+	{{ assessmentItem({
+		heading: 'Value to UK Economy',
+		link: {
+			text: 'Add value to UK economy',
+			href: urls.barriers.assessment.economyValue( barrier.id )
+		},
+		hint: 'The estimated value of resolving the barrier to the UK economy in GBP per year.',
+		analyst: true,
+		value: assessment.value_to_economy
+	}) }}
+
+	{{ assessmentItem({
+		heading: 'Import Market Size',
+		link: {
+			text: 'Add import market size',
+			href: urls.barriers.assessment.marketSize( barrier.id )
+		},
+		hint: 'The size of the import market that this barrier is limiting UK access to in GBP per year.',
+		analyst: true,
+		value: assessment.import_market_size
+	}) }}
+
+	{{ assessmentItem({
+		heading: 'Value of currently affected UK exports',
+		link: {
+			text: 'Add UK export value',
+			href: urls.barriers.assessment.exportValue( barrier.id )
+		},
+		hint: 'The value of UK exports to the partner country that are affected by this barrier in GBP per year.',
+		analyst: true,
+		value: assessment.export_value
+	}) }}
+
+	{{ assessmentItem({
+		heading: 'Commercial Value',
+		link: {
+			text: 'Add commercial value',
+			href: urls.barriers.assessment.commercialValue( barrier.id )
+		},
+		hint: 'The value of the barrier to the affected business(es) in GBP per year.',
+		value: assessment.commercial_value
+	}) }}
+
+{% endblock %}
+

--- a/src/app/sub-apps/barriers/views/assessment/detail.njk
+++ b/src/app/sub-apps/barriers/views/assessment/detail.njk
@@ -37,7 +37,7 @@
 				{% if params.value %}
 
 					<p class="assessment-item__value">
-						&pound; {{ params.value }}
+						&pound; {{ params.value | formatNumber }}
 					</p>
 					<a class="assessment-item__edit" href="{{ params.link.href }}">Edit</a>
 

--- a/src/app/sub-apps/barriers/views/assessment/detail.njk
+++ b/src/app/sub-apps/barriers/views/assessment/detail.njk
@@ -93,7 +93,7 @@
 			<h3 class="assessment-item__sub-heading">Inital assessment made by</h3>
 			<p class="assessment-item__value">{{ assessment.created_by.name }}</p>
 
-			<a class="assessment-item__edit" href="{{ urls.barriers.assessment.economic( barrier.id ) }}">Edit</a>
+			<a class="assessment-item__edit" href="{{ urls.barriers.assessment.economic.list( barrier.id ) }}">Edit</a>
 		</div>
 
 	{% else %}
@@ -102,7 +102,7 @@
 			heading: 'Economic assessment',
 			link: {
 				text: 'Add economic assessment',
-				href: urls.barriers.assessment.economic( barrier.id )
+				href: urls.barriers.assessment.economic.new( barrier.id )
 			},
 			hint: 'The assessed economic importance of resolving this barrier relative to others in the same country.',
 			analyst: true

--- a/src/app/sub-apps/barriers/views/assessment/economic.njk
+++ b/src/app/sub-apps/barriers/views/assessment/economic.njk
@@ -1,0 +1,48 @@
+{% from 'components/radios/macro.njk' import govukRadios %}
+{% from 'components/textarea/macro.njk' import govukTextarea %}
+{% from 'app-components/heading.njk' import heading %}
+
+{% extends 'layout.njk' %}
+
+{% block page_title %}{{ super() }} - Barrier Assessment - Economic assessment{% endblock %}
+
+{% block page_content %}
+
+	{{ heading({
+		back: { href: urls.barriers.assessment.detail( barrier.id ) },
+		caption: barrier.barrier_title,
+		text: 'Economic assessment',
+		errors: errors
+	}) }}
+
+	<form action="{{ urls.barriers.assessment.economic( barrier.id ) }}" method="POST" class="restrict-width">
+		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+		{{ govukRadios({
+
+			name: 'impact',
+			fieldset: {
+				legend: {
+					text: 'What is the economic impact of the barrier?',
+					classes: 'govuk-fieldset__legend--s'
+				}
+			},
+			items: impact,
+			errorMessage: errors | errorForName( 'impact-1' )
+		}) }}
+
+		{{ govukTextarea( {
+
+			label: {
+				text: 'Explain the assessment',
+				classes: 'govuk-label--s'
+			},
+			id: 'description',
+			name: 'description',
+			value: description,
+			errorMessage: errors | errorForName( 'description' )
+		} ) }}
+
+		<input type="submit" value="Save and exit to barrier" class="govuk-button">
+	</form>
+{% endblock %}

--- a/src/app/sub-apps/barriers/views/assessment/economic.njk
+++ b/src/app/sub-apps/barriers/views/assessment/economic.njk
@@ -1,10 +1,19 @@
 {% from 'components/radios/macro.njk' import govukRadios %}
 {% from 'components/textarea/macro.njk' import govukTextarea %}
+{% from "components/file-upload/macro.njk" import govukFileUpload %}
 {% from 'app-components/heading.njk' import heading %}
+{% from 'app-components/attached-documents.njk' import attachedDocuments %}
 
 {% extends 'layout.njk' %}
 
 {% block page_title %}{{ super() }} - Barrier Assessment - Economic assessment{% endblock %}
+
+{% block body_script %}
+	{{ super() }}
+	<script>
+		ma.pages.barrier.assessment();
+	</script>
+{% endblock %}
 
 {% block page_content %}
 
@@ -15,8 +24,7 @@
 		errors: errors
 	}) }}
 
-	<form action="{{ urls.barriers.assessment.economic( barrier.id ) }}" method="POST" class="restrict-width">
-		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
+	<form action="{{ urls.barriers.assessment.economic( barrier.id ) }}?_csrf={{ csrfToken }}" method="POST" enctype="multipart/form-data" class="restrict-width"  data-xhr-upload="{{ xhr.upload }}?_csrf={{ csrfToken }}" data-xhr-delete="{{ xhr.delete }}?_csrf={{ csrfToken }}">
 
 		{{ govukRadios({
 
@@ -43,6 +51,29 @@
 			errorMessage: errors | errorForName( 'description' )
 		} ) }}
 
-		<input type="submit" value="Save and exit to barrier" class="govuk-button">
+
+		<h3 class="govuk-label--s">Add supporting documents (optional)</h3>
+
+		{{ attachedDocuments( documents ) }}
+
+		{{ govukFileUpload({
+			id: 'document',
+			name: 'document',
+			classes: 'file-upload__input js-file-input',
+			formGroup: {
+				classes: 'file-upload js-form-group'
+			},
+			label: {
+				text: 'Attach a document',
+				classes: 'visually-hidden'
+			},
+			hint: {
+				classes: 'file-upload__size-limit js-max-file-size',
+				html: '(file size limit <strong>' + maxFileSize + '</strong>)'
+			},
+			errorMessage: errors | errorForName( 'document' )
+		}) }}
+
+		<input type="submit" value="Save and exit to barrier" class="govuk-button js-submit-button">
 	</form>
 {% endblock %}

--- a/src/app/sub-apps/barriers/views/assessment/economic.njk
+++ b/src/app/sub-apps/barriers/views/assessment/economic.njk
@@ -25,7 +25,7 @@
 		errors: errors
 	}) }}
 
-	<form action="{{ urls.barriers.assessment.economic( barrier.id ) }}?_csrf={{ csrfToken }}" method="POST" enctype="multipart/form-data" class="restrict-width"  data-xhr-upload="{{ xhr.upload }}?_csrf={{ csrfToken }}" data-xhr-delete="{{ xhr.delete }}?_csrf={{ csrfToken }}">
+	<form action="{{ urls.barriers.assessment.economic.list( barrier.id ) }}?_csrf={{ csrfToken }}" method="POST" enctype="multipart/form-data" class="restrict-width"  data-xhr-upload="{{ xhr.upload }}?_csrf={{ csrfToken }}" data-xhr-delete="{{ xhr.delete }}?_csrf={{ csrfToken }}">
 
 		{{ govukRadios({
 

--- a/src/app/sub-apps/barriers/views/assessment/economic.njk
+++ b/src/app/sub-apps/barriers/views/assessment/economic.njk
@@ -1,6 +1,7 @@
 {% from 'components/radios/macro.njk' import govukRadios %}
 {% from 'components/textarea/macro.njk' import govukTextarea %}
 {% from "components/file-upload/macro.njk" import govukFileUpload %}
+{% from 'components/warning-text/macro.njk' import govukWarningText %}
 {% from 'app-components/heading.njk' import heading %}
 {% from 'app-components/attached-documents.njk' import attachedDocuments %}
 
@@ -72,6 +73,11 @@
 				html: '(file size limit <strong>' + maxFileSize + '</strong>)'
 			},
 			errorMessage: errors | errorForName( 'document' )
+		}) }}
+
+		{{ govukWarningText({
+			text: 'To be completed by the Market Access Analysts',
+			iconFallbackText: 'Warning'
 		}) }}
 
 		<input type="submit" value="Save and exit to barrier" class="govuk-button js-submit-button">

--- a/src/app/sub-apps/barriers/views/assessment/economic.njk
+++ b/src/app/sub-apps/barriers/views/assessment/economic.njk
@@ -18,7 +18,7 @@
 {% block page_content %}
 
 	{{ heading({
-		back: { href: urls.barriers.assessment.detail( barrier.id ) },
+		back: { href: urls.barriers.assessment.documents.cancel( barrier.id ) },
 		caption: barrier.barrier_title,
 		text: 'Economic assessment',
 		errors: errors

--- a/src/app/sub-apps/barriers/views/assessment/economy-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/economy-value.njk
@@ -1,3 +1,4 @@
+{% from 'components/warning-text/macro.njk' import govukWarningText %}
 {% from 'app-components/currency-input.njk' import currencyInput %}
 {% from 'app-components/heading.njk' import heading %}
 
@@ -14,14 +15,22 @@
 		errors: errors
 	}) }}
 
+	{{ govukWarningText({
+		text: 'To be completed by the Market Access Analysts',
+		iconFallbackText: 'Warning'
+	}) }}
+
 	<form action="{{ urls.barriers.assessment.economyValue( barrier.id ) }}" method="POST" class="restrict-width">
 		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
 		{{ currencyInput( {
 
 			label: {
-				text: 'What is the total value of the barrier to the UK economy per year?',
+				text: 'What is the total value of the barrier to the UK economy?',
 				classes: 'govuk-label--s'
+			},
+			hint: {
+				text: 'The estimated value of resolving the barrier to the UK economy in GBP per year.'
 			},
 			id: 'value',
 			name: 'value',

--- a/src/app/sub-apps/barriers/views/assessment/economy-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/economy-value.njk
@@ -1,0 +1,35 @@
+{% from 'app-components/currency-input.njk' import currencyInput %}
+{% from 'app-components/heading.njk' import heading %}
+
+{% extends 'layout.njk' %}
+
+{% block page_title %}{{ super() }} - Barrier Assessment - UK economy value{% endblock %}
+
+{% block page_content %}
+
+	{{ heading({
+		back: { href: urls.barriers.assessment.detail( barrier.id ) },
+		caption: barrier.barrier_title,
+		text: 'Value to UK Economy',
+		errors: errors
+	}) }}
+
+	<form action="{{ urls.barriers.assessment.economyValue( barrier.id ) }}" method="POST" class="restrict-width">
+		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+		{{ currencyInput( {
+
+			label: {
+				text: 'What is the total value of the barrier to the UK economy per year?',
+				classes: 'govuk-label--s'
+			},
+			id: 'value',
+			name: 'value',
+			classes: 'govuk-input--currency',
+			value: value,
+			errorMessage: errors | errorForName( 'value' )
+		} ) }}
+
+		<input type="submit" value="Save and exit to barrier" class="govuk-button">
+	</form>
+{% endblock %}

--- a/src/app/sub-apps/barriers/views/assessment/economy-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/economy-value.njk
@@ -30,7 +30,7 @@
 			id: 'value',
 			name: 'value',
 			classes: 'govuk-input--currency',
-			value: value,
+			value: value | formatNumber,
 			errorMessage: errors | errorForName( 'value' )
 		} ) }}
 

--- a/src/app/sub-apps/barriers/views/assessment/economy-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/economy-value.njk
@@ -15,11 +15,6 @@
 		errors: errors
 	}) }}
 
-	{{ govukWarningText({
-		text: 'To be completed by the Market Access Analysts',
-		iconFallbackText: 'Warning'
-	}) }}
-
 	<form action="{{ urls.barriers.assessment.economyValue( barrier.id ) }}" method="POST" class="restrict-width">
 		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
@@ -38,6 +33,11 @@
 			value: value,
 			errorMessage: errors | errorForName( 'value' )
 		} ) }}
+
+		{{ govukWarningText({
+			text: 'To be completed by the Market Access Analysts',
+			iconFallbackText: 'Warning'
+		}) }}
 
 		<input type="submit" value="Save and exit to barrier" class="govuk-button">
 	</form>

--- a/src/app/sub-apps/barriers/views/assessment/export-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/export-value.njk
@@ -15,11 +15,6 @@
 		errors: errors
 	}) }}
 
-	{{ govukWarningText({
-		text: 'To be completed by the Market Access Analysts',
-		iconFallbackText: 'Warning'
-	}) }}
-
 	<form action="{{ urls.barriers.assessment.exportValue( barrier.id ) }}" method="POST" class="restrict-width">
 		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
@@ -38,6 +33,11 @@
 			value: value,
 			errorMessage: errors | errorForName( 'value' )
 		} ) }}
+
+		{{ govukWarningText({
+			text: 'To be completed by the Market Access Analysts',
+			iconFallbackText: 'Warning'
+		}) }}
 
 		<input type="submit" value="Save and exit to barrier" class="govuk-button">
 	</form>

--- a/src/app/sub-apps/barriers/views/assessment/export-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/export-value.njk
@@ -1,3 +1,4 @@
+{% from 'components/warning-text/macro.njk' import govukWarningText %}
 {% from 'app-components/currency-input.njk' import currencyInput %}
 {% from 'app-components/heading.njk' import heading %}
 
@@ -14,14 +15,22 @@
 		errors: errors
 	}) }}
 
+	{{ govukWarningText({
+		text: 'To be completed by the Market Access Analysts',
+		iconFallbackText: 'Warning'
+	}) }}
+
 	<form action="{{ urls.barriers.assessment.exportValue( barrier.id ) }}" method="POST" class="restrict-width">
 		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
 		{{ currencyInput( {
 
 			label: {
-				text: 'What is the value of currently affected UK exports to the partner country per year?',
+				text: 'What is the value of currently affected UK exports?',
 				classes: 'govuk-label--s'
+			},
+			hint: {
+				text: 'The value of UK exports to the partner country that are affected by this barrier in GBP per year.'
 			},
 			id: 'value',
 			name: 'value',

--- a/src/app/sub-apps/barriers/views/assessment/export-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/export-value.njk
@@ -1,0 +1,35 @@
+{% from 'app-components/currency-input.njk' import currencyInput %}
+{% from 'app-components/heading.njk' import heading %}
+
+{% extends 'layout.njk' %}
+
+{% block page_title %}{{ super() }} - Barrier Assessment - Affected UK exports{% endblock %}
+
+{% block page_content %}
+
+	{{ heading({
+		back: { href: urls.barriers.assessment.detail( barrier.id ) },
+		caption: barrier.barrier_title,
+		text: 'Value of currently affected UK exports',
+		errors: errors
+	}) }}
+
+	<form action="{{ urls.barriers.assessment.exportValue( barrier.id ) }}" method="POST" class="restrict-width">
+		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+		{{ currencyInput( {
+
+			label: {
+				text: 'What is the value of currently affected UK exports to the partner country per year?',
+				classes: 'govuk-label--s'
+			},
+			id: 'value',
+			name: 'value',
+			classes: 'govuk-input--currency',
+			value: value,
+			errorMessage: errors | errorForName( 'value' )
+		} ) }}
+
+		<input type="submit" value="Save and exit to barrier" class="govuk-button">
+	</form>
+{% endblock %}

--- a/src/app/sub-apps/barriers/views/assessment/export-value.njk
+++ b/src/app/sub-apps/barriers/views/assessment/export-value.njk
@@ -30,7 +30,7 @@
 			id: 'value',
 			name: 'value',
 			classes: 'govuk-input--currency',
-			value: value,
+			value: value | formatNumber,
 			errorMessage: errors | errorForName( 'value' )
 		} ) }}
 

--- a/src/app/sub-apps/barriers/views/assessment/market-size.njk
+++ b/src/app/sub-apps/barriers/views/assessment/market-size.njk
@@ -1,3 +1,4 @@
+{% from 'components/warning-text/macro.njk' import govukWarningText %}
 {% from 'app-components/currency-input.njk' import currencyInput %}
 {% from 'app-components/heading.njk' import heading %}
 
@@ -14,14 +15,22 @@
 		errors: errors
 	}) }}
 
+	{{ govukWarningText({
+		text: 'To be completed by the Market Access Analysts',
+		iconFallbackText: 'Warning'
+	}) }}
+
 	<form action="{{ urls.barriers.assessment.marketSize( barrier.id ) }}" method="POST" class="restrict-width">
 		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
 		{{ currencyInput( {
 
 			label: {
-				text: 'What is the size of the import market this barrier is limiting access to per year?',
+				text: 'What is the size of the import market?',
 				classes: 'govuk-label--s'
+			},
+			hint: {
+				text: 'The size of the import market that this barrier is limiting UK access to in GBP per year.'
 			},
 			id: 'value',
 			name: 'value',

--- a/src/app/sub-apps/barriers/views/assessment/market-size.njk
+++ b/src/app/sub-apps/barriers/views/assessment/market-size.njk
@@ -1,0 +1,35 @@
+{% from 'app-components/currency-input.njk' import currencyInput %}
+{% from 'app-components/heading.njk' import heading %}
+
+{% extends 'layout.njk' %}
+
+{% block page_title %}{{ super() }} - Barrier Assessment - Import market size{% endblock %}
+
+{% block page_content %}
+
+	{{ heading({
+		back: { href: urls.barriers.assessment.detail( barrier.id ) },
+		caption: barrier.barrier_title,
+		text: 'Import Market Size',
+		errors: errors
+	}) }}
+
+	<form action="{{ urls.barriers.assessment.marketSize( barrier.id ) }}" method="POST" class="restrict-width">
+		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+		{{ currencyInput( {
+
+			label: {
+				text: 'What is the size of the import market this barrier is limiting access to per year?',
+				classes: 'govuk-label--s'
+			},
+			id: 'value',
+			name: 'value',
+			classes: 'govuk-input--currency',
+			value: value,
+			errorMessage: errors | errorForName( 'value' )
+		} ) }}
+
+		<input type="submit" value="Save and exit to barrier" class="govuk-button">
+	</form>
+{% endblock %}

--- a/src/app/sub-apps/barriers/views/assessment/market-size.njk
+++ b/src/app/sub-apps/barriers/views/assessment/market-size.njk
@@ -30,7 +30,7 @@
 			id: 'value',
 			name: 'value',
 			classes: 'govuk-input--currency',
-			value: value,
+			value: value | formatNumber,
 			errorMessage: errors | errorForName( 'value' )
 		} ) }}
 

--- a/src/app/sub-apps/barriers/views/assessment/market-size.njk
+++ b/src/app/sub-apps/barriers/views/assessment/market-size.njk
@@ -15,11 +15,6 @@
 		errors: errors
 	}) }}
 
-	{{ govukWarningText({
-		text: 'To be completed by the Market Access Analysts',
-		iconFallbackText: 'Warning'
-	}) }}
-
 	<form action="{{ urls.barriers.assessment.marketSize( barrier.id ) }}" method="POST" class="restrict-width">
 		<input type="hidden" name="_csrf" value="{{ csrfToken }}">
 
@@ -38,6 +33,11 @@
 			value: value,
 			errorMessage: errors | errorForName( 'value' )
 		} ) }}
+
+		{{ govukWarningText({
+			text: 'To be completed by the Market Access Analysts',
+			iconFallbackText: 'Warning'
+		}) }}
 
 		<input type="submit" value="Save and exit to barrier" class="govuk-button">
 	</form>

--- a/src/app/sub-apps/barriers/views/detail.njk
+++ b/src/app/sub-apps/barriers/views/detail.njk
@@ -360,7 +360,16 @@
 							 {{ item.text }}
 						</p>
 						{%- endif %}
+
+				{%- elif item.isAssessment -%}
+
+					<h4 class="event-list__item__heading">{{ item.date | dateOnly }}<span class="event-list__item__heading__recede"> at {{ item.date | time }} (GMT)</span></h4>
+
+					<p class="event-list__item__text">
+						<a href="{{ urls.barriers.assessment.detail( barrier.id ) }}">{{ item.name }}</a> {{ 'edited' if item.isEdit else 'added'}} {{ ' by ' + item.user.name if item.user.name }}.
+					</p>
 				{%- endif %}
+
 			</li>
 			{% endfor %}
 

--- a/src/app/sub-apps/barriers/views/detail.njk
+++ b/src/app/sub-apps/barriers/views/detail.njk
@@ -61,7 +61,7 @@
 			<div class="attachments">
 				<h3 class="attachments__heading">Attached documents</h3>
 				<ul class="attachments__list js-documents-list">
-				{%-for document in params.documents %}
+				{%- for document in params.documents %}
 					{% if document %}{# ignore existing uploads in session which won't have a document - can be removed in next release #}
 
 					{%- set deleteUrl %}

--- a/src/app/views/app-components/attached-documents.njk
+++ b/src/app/views/app-components/attached-documents.njk
@@ -1,0 +1,20 @@
+{% macro attachedDocuments( documents ) -%}
+	{% if documents and documents.length %}
+	<div class="attachments">
+		<h3 class="attachments__heading">Attached documents</h3>
+		<ul class="attachments__list js-documents-list">
+		{%- for document in documents %}
+			{% if document %}
+
+				<li class="attachments__list__item">
+					<span class="attachments__list__item__file-name">{{ document.name }} - {{ document.size }}</span>
+					<a href="{{ document.deleteUrl }}" class="attachments__list__item__delete" data-document-id="{{ document.id }}">Delete</a>
+					<input type="hidden" name="documentIds" value="{{ document.id }}">
+				</li>
+
+			{% endif %}
+		{%- endfor %}
+		</ul>
+	</div>
+	{% endif %}
+{% endmacro %}

--- a/src/app/views/app-components/barrier-tabs.njk
+++ b/src/app/views/app-components/barrier-tabs.njk
@@ -1,8 +1,8 @@
 {% from 'app-components/tabs.njk' import tabs %}
 
 {% macro barrierTabs( barrierId, active = 'detail' ) %}
-	{{ tabs([
-		{
+	{{ tabs({
+		items: [{
 			href: urls.barriers.detail( barrierId ),
 			text: 'Barrier information',
 			isCurrent: ( active == 'detail' )
@@ -10,8 +10,11 @@
 			href: urls.barriers.team.list( barrierId ),
 			text: 'Barrier team',
 			isCurrent: ( active == 'team' )
-		}
-	], {
+		},{
+			href: urls.barriers.assessment.detail( barrierId ),
+			text: 'Assessment',
+			isCurrent: ( active == 'assessment' )
+		}],
 		classes: 'page-tabs--no-margin'
 	}) }}
 {% endmacro %}

--- a/src/app/views/app-components/currency-input.njk
+++ b/src/app/views/app-components/currency-input.njk
@@ -1,0 +1,54 @@
+{% from "components/error-message/macro.njk" import govukErrorMessage -%}
+{% from "components/hint/macro.njk" import govukHint %}
+{% from "components/label/macro.njk" import govukLabel %}
+
+{% macro currencyInput( params ) %}
+	{#- a record of other elements that we need to associate with the input using
+	aria-describedby – for example hints or error messages -#}
+	{% set describedBy = params.describedBy if params.describedBy else "" %}
+	<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+		{{ govukLabel({
+			html: params.label.html,
+			text: params.label.text,
+			classes: params.label.classes,
+			isPageHeading: params.label.isPageHeading,
+			attributes: params.label.attributes,
+			for: params.id
+		}) | indent(2) | trim }}
+		{% if params.hint %}
+			{% set hintId = params.id + '-hint' %}
+			{% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+			{{ govukHint({
+				id: hintId,
+				classes: params.hint.classes,
+				attributes: params.hint.attributes,
+				html: params.hint.html,
+				text: params.hint.text
+			}) | indent(2) | trim }}
+		{% endif %}
+		{% if params.errorMessage %}
+			{% set errorId = params.id + '-error' %}
+			{% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+			{{ govukErrorMessage({
+				id: errorId,
+				classes: params.errorMessage.classes,
+				attributes: params.errorMessage.attributes,
+				html: params.errorMessage.html,
+				text: params.errorMessage.text,
+				visuallyHiddenText: params.errorMessage.visuallyHiddenText
+			}) | indent(2) | trim }}
+		{% endif %}
+
+		<div class="currency-input">
+			<span class="currency-input__prefix" title="GBP">&pound;</span>
+			<div class="currency-input__value">
+				<input class="currency-input__value__input govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
+				{%- if params.value %} value="{{ params.value}}"{% endif %}
+				{%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+				{%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
+				{%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
+				{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+			</div>
+		</div>
+	</div>
+{% endmacro %}

--- a/src/app/views/app-components/dashboard-heading.njk
+++ b/src/app/views/app-components/dashboard-heading.njk
@@ -30,7 +30,7 @@
 	</div>
 
 	<div class="page-tabs-container">
-		{{ tabs( data.tabs ) }}
+		{{ tabs( { items: data.tabs } ) }}
 		{% if data.canAddWatchList %}
 		<a class="page-tabs-add-watch-list" href="{{ urls.findABarrier() }}"><span class="circle-icon">&#xFF0B</span> add watch list</a>
 		{% endif %}

--- a/src/app/views/app-components/tabs.njk
+++ b/src/app/views/app-components/tabs.njk
@@ -10,9 +10,9 @@
 	{%- endif -%}
 {% endmacro %}
 
-{% macro tabs( items, params ) %}
+{% macro tabs( params ) %}
 	<ul class="page-tabs{{ ( ' ' + params.classes ) if params.classes }}">
-		{%- for item in items %}
+		{%- for item in params.items %}
 			{{- tab( item ) -}}
 		{%- endfor %}
 	</ul>

--- a/src/app/views/layout.njk
+++ b/src/app/views/layout.njk
@@ -108,6 +108,7 @@
 	<script src="/public/js/components/Modal.js"></script>
 	<script src="/public/js/components/DeleteModal.js"></script>
 	<script src="/public/js/components/ToggleBox.js"></script>
+	<script src="/public/js/components/AttachmentForm.js"></script>
 	<script src="/public/js/pages/index.js"></script>
 	<script src="/public/js/pages/report/index.js"></script>
 	<script src="/public/js/pages/report/is-resolved.js"></script>
@@ -117,6 +118,7 @@
 	<script src="/public/js/pages/barrier/edit.js"></script>
 	<script src="/public/js/pages/barrier/detail.js"></script>
 	<script src="/public/js/pages/barrier/team.js"></script>
+	<script src="/public/js/pages/barrier/assessment.js"></script>
 	<script src="/public/js/pages/watch-list.js"></script>
 	<!-- endbuild -->
 	<script>ma.init();</script>

--- a/src/app/views/watch-list.njk
+++ b/src/app/views/watch-list.njk
@@ -1,9 +1,7 @@
 {% from 'components/input/macro.njk' import govukInput %}
 {% from 'components/radios/macro.njk' import govukRadios %}
-{% from "components/warning-text/macro.njk" import govukWarningText %}
 {% from 'app-components/heading.njk' import heading %}
 {% from 'app-components/details-list.njk' import detailsList %}
-{% from 'app-components/callout.njk' import callout %}
 
 {% extends 'layout.njk' %}
 

--- a/src/data/faker/backend.js
+++ b/src/data/faker/backend.js
@@ -14,6 +14,7 @@ const jsonFiles = {
 	'barriers/interactions': generateSchema( '/backend/barriers/interactions' ),
 	'barriers/history': generateSchema( '/backend/barriers/history' ),
 	'barriers/members': generateSchema( '/backend/barriers/members' ),
+	'barriers/assessment': generateSchema( '/backend/barriers/assessment' ),
 };
 
 writeJsonFiles( OUTPUT_PATH, jsonFiles );

--- a/src/data/faker/backend.js
+++ b/src/data/faker/backend.js
@@ -15,6 +15,7 @@ const jsonFiles = {
 	'barriers/history': generateSchema( '/backend/barriers/history' ),
 	'barriers/members': generateSchema( '/backend/barriers/members' ),
 	'barriers/assessment': generateSchema( '/backend/barriers/assessment' ),
+	'barriers/assessment_history': generateSchema( '/backend/barriers/assessment_history' ),
 };
 
 writeJsonFiles( OUTPUT_PATH, jsonFiles );

--- a/src/data/schema/$refs/common.json
+++ b/src/data/schema/$refs/common.json
@@ -177,5 +177,19 @@
 			"id": { "$ref": "#/small-int" },
 			"name": { "$ref": "#/word" }
 		}
+	},
+
+	"document": {
+		"type": "object",
+		"required": [ "id", "name", "size", "status" ],
+		"properties": {
+			"id": { "$ref": "#/uuid" },
+			"name": { "$ref": "#/word" },
+			"size": { "$ref": "#/small-int" },
+			"status": {
+				"type": "string",
+				"enum": [ "virus_scanned" ]
+			}
+		}
 	}
 }

--- a/src/data/schema/$refs/common.json
+++ b/src/data/schema/$refs/common.json
@@ -155,5 +155,14 @@
 				"pattern": "COMPLETED|IN PROGRESS"
 			}
 		}
+	},
+
+	"user": {
+		"type": "object",
+		"required": [ "id", "name" ],
+		"properties": {
+			"id": { "$ref": "#/small-int" },
+			"name": { "$ref": "#/word" }
+		}
 	}
 }

--- a/src/data/schema/$refs/common.json
+++ b/src/data/schema/$refs/common.json
@@ -4,6 +4,19 @@
 		"faker": "random.uuid"
 	},
 
+	"nullable-uuid-array": {
+		"oneOf":[
+			{
+				"enum": [ null ]
+			},{
+				"type": "array",
+				"minItems": 1,
+				"maxItems": 4,
+				"items": { "$ref": "#/uuid" }
+			}
+		]
+	},
+
 	"barrier-code": {
 		"type": "string",
 		"pattern": "B-[0-9]{2}-[A-Z0-9]{3}"

--- a/src/data/schema/backend/barriers/assessment.json
+++ b/src/data/schema/backend/barriers/assessment.json
@@ -1,0 +1,34 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "Detail of an assessment",
+
+	"type": "object",
+	"required": [
+		"id",
+		"impact",
+		"explantion",
+		"value_to_economy",
+		"import_market_size",
+		"commercial_value",
+		"export_value",
+		"documents",
+		"created_on",
+		"created_by"
+	],
+	"properties": {
+
+		"id": { "$ref": "$refs/common.json#/small-int" },
+		"impact": {
+			"type": "string",
+			"enum": [ "ONE", "TWO", "THREE", "FOUR" ]
+		},
+		"explantion": { "$ref": "$refs/common.json#/words" },
+		"value_to_economy": { "$ref": "$refs/common.json#/int" },
+		"import_market_size": { "$ref": "$refs/common.json#/int" },
+		"commercial_value": { "$ref": "$refs/common.json#/int" },
+		"export_value": { "$ref": "$refs/common.json#/int" },
+		"documents": { "type": "array" },
+		"created_on": { "$ref": "$refs/common.json#/past-date" },
+		"created_by": { "$ref": "$refs/common.json#/user" }
+	}
+}

--- a/src/data/schema/backend/barriers/assessment.json
+++ b/src/data/schema/backend/barriers/assessment.json
@@ -27,7 +27,12 @@
 		"import_market_size": { "$ref": "$refs/common.json#/int" },
 		"commercial_value": { "$ref": "$refs/common.json#/int" },
 		"export_value": { "$ref": "$refs/common.json#/int" },
-		"documents": { "type": "array" },
+		"documents": {
+			"type": "array",
+			"minItems": 0,
+			"maxItems": 5,
+			"items": { "$ref": "$refs/common.json#/document" }
+		},
 		"created_on": { "$ref": "$refs/common.json#/past-date" },
 		"created_by": { "$ref": "$refs/common.json#/user" }
 	}

--- a/src/data/schema/backend/barriers/assessment_history.json
+++ b/src/data/schema/backend/barriers/assessment_history.json
@@ -1,0 +1,44 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "History of an assessment",
+
+	"type": "object",
+	"required": [ "barrier_id", "history" ],
+	"properties": {
+
+		"barrier_id": { "$ref": "$refs/common.json#/uuid" },
+
+		"history": {
+			"type": "array",
+			"minItems": 2,
+			"maxItems": 5,
+			"items": {
+				"$ref": "#/refs/history-item"
+			}
+		}
+	},
+
+	"refs": {
+		"history-item": {
+			"type": "object",
+			"required": [
+				"date",
+				"field",
+				"old_value",
+				"new_value",
+				"user"
+			],
+			"properties": {
+
+				"date": { "$ref": "$refs/common.json#/past-date" },
+				"field": {
+					"type": "string",
+					"enum": [ "impact", "value_to_economy" ]
+				},
+				"old_value": { "$ref": "$refs/common.json#/small-int" },
+				"new_value": { "$ref": "$refs/common.json#/small-int" },
+				"user": { "$ref": "$refs/common.json#/user" }
+			}
+		}
+	}
+}

--- a/src/data/schema/backend/barriers/barrier.json
+++ b/src/data/schema/backend/barriers/barrier.json
@@ -19,19 +19,17 @@
 		"barrier_title",
 		"problem_description",
 		"status",
-		"status_date",
-		"status_summary",
 		"reported_on",
 		"reported_by",
 		"created_on",
 		"export_country",
-		"has_legal_infringement",
-		"wto_infringement",
-		"fta_infringement",
-		"other_infringement",
-		"infringement_summary",
+		"country_admin_areas",
 		"priority",
-		"modified_on"
+		"priority_summary",
+		"modified_on",
+		"all_sectors",
+		"eu_exit_related",
+		"has_assessment"
 	],
 	"properties": {
 
@@ -91,10 +89,14 @@
 			"faker": "lorem.words"
 		},
 
-		"eu_exit_related": { "$ref": "$refs/common.json#/boolean" },
+		"eu_exit_related": {
+			"type": "number",
+			"enum": [ 0, 1, 2 ]
+		},
 
 		"problem_description": { "$ref": "$refs/common.json#/paragraph" },
 		"priority": { "$ref": "$refs/common.json#/priority" },
+		"priority_summary": { "$ref": "$refs/common.json#/paragraph" },
 
 		"status": {
 			"type": "object",
@@ -121,15 +123,10 @@
 		"created_on": { "$ref": "$refs/common.json#/past-date" },
 		"modified_on": { "$ref": "$refs/common.json#/past-date" },
 		"export_country": { "$ref": "$refs/common.json#/uuid" },
-
-		"has_legal_infringement": {
-			"type": "string",
-			"enum": [ "1", "2", "3" ]
+		"country_admin_areas": { "$ref": "$refs/common.json#/nullable-uuid-array" },
+		"all_sectors": {
+			"enum": [ null, false, true ]
 		},
-
-		"wto_infringement": { "$ref": "$refs/common.json#/boolean" },
-		"fta_infringement": { "$ref": "$refs/common.json#/boolean" },
-		"other_infringement": { "$ref": "$refs/common.json#/boolean" },
-		"infringement_summary":  { "$ref": "$refs/common.json#/paragraph" }
+		"has_assessment": { "$ref": "$refs/common.json#/boolean" }
 	}
 }

--- a/src/data/schema/backend/barriers/history.json
+++ b/src/data/schema/backend/barriers/history.json
@@ -24,15 +24,6 @@
 
 	"refs": {
 
-		"user": {
-			"type": "object",
-			"required": [ "id", "name" ],
-			"properties": {
-				"id": { "$ref": "$refs/common.json#/small-int" },
-				"name": { "$ref": "$refs/common.json#/word" }
-			}
-		},
-
 		"status-item": {
 			"type": "object",
 			"required": [
@@ -56,9 +47,7 @@
 						"event": { "$ref": "$refs/common.json#/barrier-event" }
 					}
 				},
-				"user": {
-					"$ref": "#/refs/user"
-				}
+				"user": { "$ref": "$refs/common.json#/user" }
 			}
 		},
 
@@ -84,9 +73,7 @@
 						"priority_summary": { "$ref": "$refs/common.json#/words" }
 					}
 				},
-				"user": {
-					"$ref": "#/refs/user"
-				}
+				"user": { "$ref": "$refs/common.json#/user" }
 			}
 		}
 	}

--- a/src/data/schema/backend/metadata/index.json
+++ b/src/data/schema/backend/metadata/index.json
@@ -18,7 +18,8 @@
 		"barrier_status",
 		"barrier_source",
 		"barrier_priorities",
-		"barrier_pending"
+		"barrier_pending",
+		"assessment_impact"
 	],
 	"properties": {
 
@@ -191,6 +192,18 @@
 				"TWO": { "$ref": "$refs/common.json#/words" },
 				"THREE": { "$ref": "$refs/common.json#/words" },
 				"OTHER": { "$ref": "$refs/common.json#/word" }
+			}
+		},
+
+		"assessment_impact": {
+			"type": "object",
+			"required": [ "I_ONE", "I_TWO", "I_THREE", "I_FOUR" ],
+			"properties": {
+
+				"I_ONE": { "$ref": "$refs/common.json#/word" },
+				"I_TWO": { "$ref": "$refs/common.json#/words" },
+				"I_THREE": { "$ref": "$refs/common.json#/words" },
+				"I_FOUR": { "$ref": "$refs/common.json#/word" }
 			}
 		}
 	}

--- a/src/public/js/components/AttachmentForm.js
+++ b/src/public/js/components/AttachmentForm.js
@@ -1,0 +1,140 @@
+ma.components.AttachmentForm = (function( jessie ){
+
+	if( !( ma.xhr2 && ( typeof FormData !== 'undefined' ) && jessie.bind ) ){ return; }
+
+	var bind = jessie.bind;
+
+	function AttachmentForm( fileUpload, attachments, submitButton, deleteUrl ){
+
+		if( !fileUpload ){ throw new Error( 'fileUpload is required' ); }
+		if( !attachments ){ throw new Error( 'attachments is required' ); }
+		if( !submitButton ){ throw new Error( 'submitButton is required' ); }
+		if( !deleteUrl ){ throw new Error( 'deleteUrl is required' ); }
+
+		this.fileUpload = fileUpload;
+		this.attachments = attachments;
+		this.submitButton = submitButton;
+		this.deleteUrl = deleteUrl;
+
+		fileUpload.events.file.subscribe( bind( this.newFile, this ) );
+		attachments.events.delete.subscribe( bind( this.deleteDocument, this ) );
+
+	}
+
+	AttachmentForm.prototype.showError = function( message ){
+
+		this.submitButton.disabled = false;
+		this.fileUpload.setError( message );
+		this.fileUpload.showLink();
+	};
+
+	AttachmentForm.prototype.updateProgress = function( e ){
+
+		if( e.lengthComputable ){
+
+			if( e.loaded === e.total ){
+
+				this.fileUpload.setProgress( 'scanning file for viruses...' );
+
+			} else {
+
+				this.fileUpload.setProgress( 'uploading file... ' + Math.floor( ( e.loaded / e.total ) * 100 ) + '%' );
+			}
+		}
+	};
+
+	AttachmentForm.prototype.transferFailed = function(){
+
+		this.showError( 'Upload of document cancelled, try again.' );
+	};
+
+	AttachmentForm.prototype.transferCanceled = function(){
+
+		this.showError( 'Upload of document cancelled, try again.' );
+	};
+
+	AttachmentForm.prototype.loaded = function( e ){
+
+		var xhr = e.target;
+		var responseCode = xhr.status;
+		var data;
+
+		try {
+
+			data = JSON.parse( xhr.response );
+
+		} catch( e ){
+
+			data = {};
+		}
+
+		if( responseCode === 200 ){
+
+			var documentId = data.documentId;
+			var file = data.file;
+
+			if( documentId && file ){
+
+				this.submitButton.disabled = false;
+				this.fileUpload.showLink();
+				this.attachments.addItem( {
+					id: documentId,
+					name: file.name,
+					size: file.size
+				} );
+
+			} else {
+
+				this.showError( 'There was an issue uploading the document, try again' );
+			}
+
+		} else if( responseCode === 401 ){
+
+			this.showError( data.message );
+
+		} else {
+
+			var message = ( data.message || 'A system error has occured, so the file has not been uploaded. Try again.' );
+			this.showError( message );
+		}
+	};
+
+	AttachmentForm.prototype.newFile = function( file ){
+
+		var xhr2 = ma.xhr2();
+		var formData = new FormData();
+
+		this.submitButton.disabled = true;
+		formData.append( 'document', file );
+
+		if( xhr2.upload ){
+
+			xhr2.upload.addEventListener( 'progress', bind( this.updateProgress, this ), false );
+		}
+
+		xhr2.addEventListener( 'error', bind( this.transferFailed, this ), false );
+		xhr2.addEventListener( 'abort', bind( this.transferCanceled, this ), false );
+		xhr2.addEventListener( 'load', bind( this.loaded, this ), false );
+
+		xhr2.open( 'POST', this.fileUpload.action, true );
+		xhr2.send( formData );
+
+		this.fileUpload.setProgress( 'uploading file... 0%' );
+	};
+
+	AttachmentForm.prototype.deleteDocument = function( documentId ){
+
+		if( !documentId ){ return; }
+
+		var xhr = ma.xhr2();
+		var url = this.deleteUrl.replace( ':uuid', documentId );
+
+		xhr.open( 'POST', url, true );
+		xhr.send();
+
+		this.attachments.removeItem( documentId );
+	};
+
+	return AttachmentForm;
+
+}( jessie ));

--- a/src/public/js/pages/barrier/assessment.js
+++ b/src/public/js/pages/barrier/assessment.js
@@ -1,4 +1,4 @@
-ma.pages.barrier.detail = (function( doc, jessie ){
+ma.pages.barrier.assessment = (function(){
 
 	function setupAttachments(){
 
@@ -22,12 +22,10 @@ ma.pages.barrier.detail = (function( doc, jessie ){
 		var submitButton = jessie.queryOne( '.js-submit-button' );
 		var form = fileUpload.form;
 
-		if( !submitButton ){ return; }
-		if( !form ){ return; }
+		if( !submitButton ){ throw new Error( 'Submit button not found' ); }
+		if( !form ){ throw new Error( 'No form found' ); }
 
 		var deleteUrl = jessie.getElementData( form, 'xhr-delete' );
-
-		if( !deleteUrl ){ return; }
 
 		try {
 
@@ -39,46 +37,12 @@ ma.pages.barrier.detail = (function( doc, jessie ){
 		return form;
 	}
 
-	function setupForm( form, noteErrorText ){
+	return function(){
 
-		if( !ma.components.TextArea ){ return; }
-
-		var note;
-
-		try {
-
-			note = new ma.components.TextArea( {
-				group: '.js-note-group',
-				input: '.js-note-text'
-			} );
-
-		} catch( e ){ return; }
-
-		function handleFormSubmit( e ){
-
-			if( !note.hasValue() ){
-
-				jessie.cancelDefault( e );
-				note.setError( noteErrorText );
-				note.focus();
-			}
-		}
-
-		jessie.attachListener( form, 'submit', handleFormSubmit );
-	}
-
-	return function( opts ){
-
-		var form = setupAttachments();
-		if( form ){ setupForm( form, opts.noteErrorText ); }
-
-		if( ma.components.ToggleLinks ){
-			new ma.components.ToggleLinks( opts.toggleLinks );
-		}
+		setupAttachments();
 
 		if( ma.components.DeleteModal ){
 			new ma.components.DeleteModal();
 		}
 	};
-
-}( document, jessie ));
+})();

--- a/src/public/sass/app-objects/_document-list.scss
+++ b/src/public/sass/app-objects/_document-list.scss
@@ -1,0 +1,20 @@
+.document-list {
+	list-style: none;
+	padding: govuk-em( 10, 16 ) govuk-em( 15, 16 );
+	border: 1px solid $govuk-grey-2;
+	margin: 0;
+}
+
+.document-list--assessment {
+	max-width: 600px;
+	box-sizing: border-box;
+}
+
+.document-list__item {
+
+	margin-bottom: govuk-em( 5, 16 );
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
+}

--- a/src/public/sass/main.scss
+++ b/src/public/sass/main.scss
@@ -33,7 +33,7 @@ $govuk-images-path: '/govuk-public/images/';
 @import 'components/checkboxes/checkboxes';
 @import 'components/input/input';
 @import 'components/select/select';
-@import 'components/warning-text/warning-text';
+@import 'components/inset-text/inset-text';
 @import 'components/textarea/textarea';
 @import 'components/back-link/back-link';
 @import 'components/error-summary/error-summary';
@@ -94,6 +94,7 @@ $govuk-images-path: '/govuk-public/images/';
 @import 'pages/barrier/detail';
 @import 'pages/barrier/type';
 @import 'pages/barrier/team';
+@import 'pages/barrier/assessment';
 @import 'pages/find-a-barrier';
 
 body:not(.js-enabled) {

--- a/src/public/sass/main.scss
+++ b/src/public/sass/main.scss
@@ -63,6 +63,7 @@ $govuk-images-path: '/govuk-public/images/';
 @import 'app-objects/inline-definition-list';
 @import 'app-objects/circle-icon';
 @import 'app-objects/static-form-group';
+@import 'app-objects/document-list';
 
 @import 'app-components/dash-button';
 @import 'app-components/dash-card';

--- a/src/public/sass/main.scss
+++ b/src/public/sass/main.scss
@@ -33,6 +33,7 @@ $govuk-images-path: '/govuk-public/images/';
 @import 'components/checkboxes/checkboxes';
 @import 'components/input/input';
 @import 'components/select/select';
+@import 'components/warning-text/warning-text';
 @import 'components/inset-text/inset-text';
 @import 'components/textarea/textarea';
 @import 'components/back-link/back-link';

--- a/src/public/sass/pages/barrier/_assessment.scss
+++ b/src/public/sass/pages/barrier/_assessment.scss
@@ -9,7 +9,7 @@
 
 .assessment-item__sub-heading {
 	@include govuk-font( 19, $weight: bold );
-	margin: govuk-em( 10, 19 ) 0 0 0;
+	margin: govuk-em( 15, 19 ) 0 govuk-em( 5, 19 ) 0;
 }
 
 .assessment-item__value {
@@ -17,13 +17,15 @@
 }
 
 .assessment-item__edit {
-
+	display: inline-block;
+	margin-top: govuk-em( 5, 16 );
 }
 
 .assessment-item-content {
 	border: 2px dashed $govuk-grey-3;
 	padding: govuk-em( 15, 16 );
 	max-width: 600px;
+	box-sizing: border-box;
 }
 
 /* .assessment-item-content__link {
@@ -42,50 +44,16 @@
 	@include govuk-font( 16 );
 }
 
-.barrier-impact-scale {
-	list-style: none;
-	margin: 0;
-	padding: 0;
-	text-align: center;
-}
 
-.barrier-impact-scale__item {
-
+.barrier-impact-value {
 	display: inline-block;
 	min-width: 200px;
 	padding: govuk-em( 5, 16 ) 0;
 	margin: 0 govuk-em( 20, 16 ) 0 0;
 	text-align: center;
-	background-color: $govuk-grey-2;
-	color: white;
-	position: relative;
-	z-index: 10;
-	font-weight: bold;
-
-	&:after {
-		content: '';
-		display: block;
-		width: govuk-em( 25, 16 );
-		border-top: 5px solid $govuk-grey-2;
-		position: absolute;
-		top: 50%;
-		left: 100%;
-		z-index: -1;
-	}
-
-	&:last-of-type {
-		&:after {
-			display: none;
-		}
-	}
-}
-
-.barrier-impact-scale__item--active {
 	background-color: $govuk-black;
-}
-
-.currency-input {
-
+	color: white;
+	font-weight: bold;
 }
 
 .currency-input__prefix {

--- a/src/public/sass/pages/barrier/_assessment.scss
+++ b/src/public/sass/pages/barrier/_assessment.scss
@@ -1,0 +1,100 @@
+.assessment-item {
+	margin-bottom: govuk-em( 45, 16 );
+}
+
+.assessment-item__heading {
+	@include govuk-font( 24, $weight: 'bold' );
+	margin-bottom: govuk-em( 5, 24 );
+}
+
+.assessment-item__sub-heading {
+	@include govuk-font( 19, $weight: bold );
+	margin: govuk-em( 10, 19 ) 0 0 0;
+}
+
+.assessment-item__value {
+	margin: 0;
+}
+
+.assessment-item__edit {
+
+}
+
+.assessment-item-content {
+	border: 2px dashed $govuk-grey-3;
+	padding: govuk-em( 15, 16 );
+	max-width: 600px;
+}
+
+/* .assessment-item-content__link {
+
+} */
+
+.assessment-item-content__hint {
+	color: $govuk-grey-1;
+	margin: 0;
+}
+
+.assessment-item-content__restriction {
+	background: $govuk-grey-4;
+	padding: govuk-em( 10, 16 );
+	margin: govuk-em( 10, 16 ) 0 0 0;
+	@include govuk-font( 16 );
+}
+
+.barrier-impact-scale {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	text-align: center;
+}
+
+.barrier-impact-scale__item {
+
+	display: inline-block;
+	min-width: 200px;
+	padding: govuk-em( 5, 16 ) 0;
+	margin: 0 govuk-em( 20, 16 ) 0 0;
+	text-align: center;
+	background-color: $govuk-grey-2;
+	color: white;
+	position: relative;
+	z-index: 10;
+	font-weight: bold;
+
+	&:after {
+		content: '';
+		display: block;
+		width: govuk-em( 25, 16 );
+		border-top: 5px solid $govuk-grey-2;
+		position: absolute;
+		top: 50%;
+		left: 100%;
+		z-index: -1;
+	}
+
+	&:last-of-type {
+		&:after {
+			display: none;
+		}
+	}
+}
+
+.barrier-impact-scale__item--active {
+	background-color: $govuk-black;
+}
+
+.currency-input {
+
+}
+
+.currency-input__prefix {
+	display: inline-block;
+	@include govuk-font( 24 );
+	vertical-align: bottom;
+	padding-bottom: 5px;
+}
+.currency-input__value {
+	width: 50%;
+	display: inline-block;
+}

--- a/src/test/app/fake-data/backend/barriers/assessment.json
+++ b/src/test/app/fake-data/backend/barriers/assessment.json
@@ -6,7 +6,20 @@
    "import_market_size": 16816,
    "commercial_value": 51888,
    "export_value": 50309,
-   "documents": [],
+   "documents": [
+		{
+         "id": "4a922639-514e-4389-8967-1fde85acaf6c",
+         "name": "consequatur",
+         "size": 13,
+         "status": "virus_scanned"
+      },
+      {
+         "id": "a3edf3fc-2933-4773-9a26-4571acdfa391",
+         "name": "eos",
+         "size": 11,
+         "status": "virus_scanned"
+      }
+	],
    "created_on": "Mon Jan 21 2019 09:09:38 GMT+0000 (Greenwich Mean Time)",
    "created_by": {
       "id": 19,

--- a/src/test/app/fake-data/backend/barriers/assessment.json
+++ b/src/test/app/fake-data/backend/barriers/assessment.json
@@ -1,0 +1,15 @@
+{
+   "id": 3,
+   "impact": "THREE",
+   "explantion": "occaecati itaque quo",
+   "value_to_economy": 55197,
+   "import_market_size": 16816,
+   "commercial_value": 51888,
+   "export_value": 50309,
+   "documents": [],
+   "created_on": "Mon Jan 21 2019 09:09:38 GMT+0000 (Greenwich Mean Time)",
+   "created_by": {
+      "id": 19,
+      "name": "voluptas"
+   }
+}

--- a/src/test/app/fake-data/backend/barriers/assessment_history.json
+++ b/src/test/app/fake-data/backend/barriers/assessment_history.json
@@ -1,0 +1,35 @@
+{
+   "barrier_id": "66794c15-ddfb-4e00-b73c-b34e5c221387",
+   "history": [
+      {
+         "date": "Thu May 16 2019 10:58:33 GMT+0100 (British Summer Time)",
+         "field": "value_to_economy",
+         "old_value": 8,
+         "new_value": 14,
+         "user": {
+            "id": 14,
+            "name": "possimus"
+         }
+      },
+      {
+         "date": "Wed May 29 2019 13:17:50 GMT+0100 (British Summer Time)",
+         "field": "impact",
+         "old_value": 5,
+         "new_value": 15,
+         "user": {
+            "id": 17,
+            "name": "nesciunt"
+         }
+      },
+      {
+         "date": "Fri Aug 24 2018 19:26:57 GMT+0100 (British Summer Time)",
+         "field": "value_to_economy",
+         "old_value": 15,
+         "new_value": 1,
+         "user": {
+            "id": 8,
+            "name": "voluptatem"
+         }
+      }
+   ]
+}

--- a/src/test/app/fake-data/backend/barriers/assessment_history.json
+++ b/src/test/app/fake-data/backend/barriers/assessment_history.json
@@ -24,7 +24,7 @@
       {
          "date": "Fri Aug 24 2018 19:26:57 GMT+0100 (British Summer Time)",
          "field": "value_to_economy",
-         "old_value": 15,
+         "old_value": null,
          "new_value": 1,
          "user": {
             "id": 8,

--- a/src/test/app/fake-data/backend/metadata/index.json
+++ b/src/test/app/fake-data/backend/metadata/index.json
@@ -350,5 +350,11 @@
       "TWO": "incidunt rem accusantium",
       "THREE": "ut quo ea",
       "OTHER": "enim"
+	},
+	"assessment_impact": {
+      "I_ONE": "sed",
+      "I_TWO": "voluptatem dolores qui",
+      "I_THREE": "qui sit aut",
+      "I_FOUR": "unde"
    }
 }

--- a/src/test/app/helpers/get-csrf-token.js
+++ b/src/test/app/helpers/get-csrf-token.js
@@ -21,7 +21,7 @@ if( typeof jasmine !== 'undefined' ){
 
 	jasmine.helpers.getCsrfTokenFromQueryParam = ( res, fail ) => {
 
-		const token = getToken( /".+?\?.*?_csrf=(.+?)[&"]/, res );
+		const token = getToken( /action=".+?\?.*?_csrf=(.+?)[&"]/, res );
 
 		if( !token ){
 			console.log( res.text );

--- a/src/test/app/helpers/mocks.js
+++ b/src/test/app/helpers/mocks.js
@@ -120,7 +120,10 @@ if( typeof jasmine !== 'undefined' ){
 			sectors: {
 				list: createBarrierSessionSpies( 'list' ),
 				all: createBarrierSessionSpies( 'all' ),
-			}
+			},
+			documents: {
+				assessment: createBarrierSessionSpies( 'assessment-douments' ),
+			},
 		}),
 
 		form: () => {
@@ -141,5 +144,52 @@ if( typeof jasmine !== 'undefined' ){
 				Form: jasmine.createSpy( 'Form' ).and.returnValue( form )
 			};
 		},
+
+		formProcessor: () => {
+
+			const process = jasmine.createSpy( 'processor.process' );
+			const processor = { process };
+			const FormProcesor = jasmine.createSpy( 'FormProcessor' ).and.returnValue( processor );
+
+			FormProcesor.processor = processor;
+
+			return FormProcesor;
+		},
+
+		documentControllers: () => {
+
+			const xhrAddCb = jasmine.createSpy( 'documentControllers.xhr.add.cb' );
+			const xhrDeleteCb = jasmine.createSpy( 'documentControllers.xhr.delete.cb' );
+			const deleteCb = jasmine.createSpy( 'documentControllers.delete.cb' );
+
+			const xhr = {
+				add: jasmine.createSpy( 'documentControllers.xhr.add' ).and.returnValue( xhrAddCb ),
+				delete: jasmine.createSpy( 'documentControllers.xhr.delete' ).and.returnValue( xhrDeleteCb ),
+			};
+			const deleteMock = jasmine.createSpy( 'documentControllers.delete' ).and.returnValue( deleteCb );
+
+			xhr.add.cb = xhrAddCb;
+			xhr.delete.cb = xhrDeleteCb;
+			deleteMock.cb = deleteCb;
+
+			return {
+
+				MAX_FILE_SIZE: faker.lorem.words(),
+				OVERSIZE_FILE_MESSAGE: faker.lorem.words(),
+				INVALID_FILE_TYPE_MESSAGE: faker.lorem.words(),
+				UPLOAD_ERROR_MESSAGE: faker.lorem.words(),
+				FILE_INFECTED_MESSAGE: faker.lorem.words(),
+
+				reportInvalidFile: jasmine.createSpy( 'documentControllers.reportInvalidFile'),
+
+				xhr,
+				delete: deleteMock,
+			};
+		},
+
+		request: ( statusCode, body = {} ) => Promise.resolve({
+			response: { isSuccess: ( statusCode === 200 ), statusCode },
+			body,
+		}),
 	};
 }


### PR DESCRIPTION
**Implementation notes**

Add a new tab to the barrier details for assessment.
The assessment is split into 5 parts, the first is the "Economic assessment" which is comprised of the impact, a description and optional documents. The others are just values that can be added. Any of the parts can be added at any point and don't have to be done in a specific order.
This involved refactoring the documents controllers and client JS to be re-used as much as possible by both the notes and assessments.

Add assessment items in the updates section of the barrier detail.
Here the "impact" field is used as a proxy to mean "Economic assessment", the other values have their respective headings

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
