### PR TITLE
Display formatted file size when editing an economic assessment

### DIFF
--- a/src/app/sub-apps/barriers/view-models/assessment/economic.js
+++ b/src/app/sub-apps/barriers/view-models/assessment/economic.js
@@ -1,3 +1,4 @@
+const fileSize = require( '../../../../lib/file-size' );
 const { documents: documentUrls } = require( '../../../../lib/urls' ).barriers.assessment;
 
 
@@ -15,6 +16,7 @@ module.exports = function( barrierId, sessionDocuments, templateValues ){
 
 		values.documents = sessionDocuments.map( ( document ) => ({
 			...document,
+			size: fileSize( document.size ),
 			deleteUrl: documentUrls.delete( barrierId, document.id )
 		}) );
 	}

--- a/src/app/sub-apps/barriers/view-models/assessment/economic.spec.js
+++ b/src/app/sub-apps/barriers/view-models/assessment/economic.spec.js
@@ -1,5 +1,6 @@
 const proxyquire = require( 'proxyquire' );
 const faker = require( 'faker' );
+const fileSize = require( '../../../../lib/file-size' );
 const modulePath = './economic';
 
 function createDoc(){
@@ -48,6 +49,7 @@ describe( 'Economic assessemnt view model', () => {
 			},
 			documents: documents.map( ( doc ) => ({
 				...doc,
+				size: fileSize( doc.size ),
 				deleteUrl: documentDeleteUrl,
 			}) ),
 		} );


### PR DESCRIPTION
When editing an economic assessment it was displaying the file size in bytes instead of formatted as kB, MB etc