### PR TITLE
Http response errors

### DIFF
--- a/src/app/controllers/find-a-barrier.js
+++ b/src/app/controllers/find-a-barrier.js
@@ -1,6 +1,7 @@
 const backend = require( '../lib/backend-service' );
 const viewModel = require( '../view-models/find-a-barrier' );
 const barrierFilters = require( '../lib/barrier-filters' );
+const HttpResponseError = require( '../lib/HttpResponseError' );
 
 module.exports = {
 
@@ -38,7 +39,7 @@ module.exports = {
 
 			} else {
 
-				next( new Error( `Got ${ response.statusCode } response from backend` ) );
+				next( new HttpResponseError( 'Unable to get barriers', response, body ) );
 			}
 
 		} catch( e ) {

--- a/src/app/controllers/find-a-barrier.spec.js
+++ b/src/app/controllers/find-a-barrier.spec.js
@@ -1,6 +1,8 @@
 const proxyquire = require( 'proxyquire' );
 const EventEmitter = require( 'events' );
+const HttpResponseError = require( '../lib/HttpResponseError' );
 const modulePath = './find-a-barrier';
+
 
 const { mocks } = jasmine.helpers;
 
@@ -200,7 +202,8 @@ describe( 'Find a barrier controller', () => {
 
 					await controller.list( req, res, next );
 
-					expect( next ).toHaveBeenCalledWith( new Error( `Got ${ statusCode } response from backend` ) );
+					expect( next ).toHaveBeenCalled();
+					expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 					expect( res.render ).not.toHaveBeenCalled();
 					checkBackendCall();
 				} );

--- a/src/app/controllers/index.js
+++ b/src/app/controllers/index.js
@@ -2,6 +2,7 @@ const urls = require( '../lib/urls' );
 const backend = require( '../lib/backend-service' );
 const dashboardViewModel = require( '../view-models/dashboard' );
 const { createList } = require( '../lib/barrier-filters' );
+const HttpResponseError = require( '../lib/HttpResponseError' );
 
 const sortData = {
 	fields: [ 'priority', 'date', 'location', 'status', 'updated' ],
@@ -68,7 +69,7 @@ module.exports = {
 
 				} else {
 
-					throw new Error( `Got ${ response.statusCode } response from backend` );
+					throw new HttpResponseError( 'Unable to get barriers', response, body );
 				}
 
 			} catch( e ){

--- a/src/app/controllers/index.spec.js
+++ b/src/app/controllers/index.spec.js
@@ -1,4 +1,5 @@
 const proxyquire = require( 'proxyquire' );
+const HttpResponseError = require( '../lib/HttpResponseError' );
 const modulePath = './index';
 
 let controller;
@@ -305,7 +306,8 @@ describe( 'Index controller', () => {
 
 						await controller.index( req, res, next );
 
-						expect( next ).toHaveBeenCalledWith( new Error( `Got ${ barriersResponse.response.statusCode } response from backend` ) );
+						expect( next ).toHaveBeenCalled();
+						expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 						expect( backend.barriers.getAll ).toHaveBeenCalledWith( req, { country: '1234' }, page, 'modified_on', 'desc' );
 						expect( res.render ).not.toHaveBeenCalled();
 					} );

--- a/src/app/lib/FormProcessor.js
+++ b/src/app/lib/FormProcessor.js
@@ -1,3 +1,4 @@
+const HttpResponseError = require( './HttpResponseError' );
 
 function FormPocessor( params = {} ){
 
@@ -30,13 +31,12 @@ FormPocessor.prototype.doSave = async function( checkResponseErrors = false ){
 
 		} else {
 
-			throw new Error( `No errors in response body, form not saved - got ${ response.statusCode } from backend` );
+			throw new HttpResponseError( 'No errors in response body, form not saved', response, body );
 		}
 
 	} else {
 
-		const err = new Error( `Unable to save form - got ${ response.statusCode } from backend` );
-		err.responseBody = body;
+		const err = new HttpResponseError( 'Unable to save form', response, body );
 
 		if( response.statusCode === 400 ){
 			err.code = 'UNHANDLED_400';

--- a/src/app/lib/backend-service.js
+++ b/src/app/lib/backend-service.js
@@ -1,6 +1,7 @@
 const backend = require( './backend-request' );
 const metadata = require( './metadata' );
 const config = require( '../config' );
+const HttpResponseError = require( './HttpResponseError' );
 
 const SCAN_CHECK_INTERVAL = config.files.scan.statusCheckInterval;
 const SCAN_MAX_ATTEMPTS = Math.round( config.files.scan.maxWaitTime / SCAN_CHECK_INTERVAL );
@@ -293,7 +294,7 @@ module.exports = {
 
 					} else {
 
-						reject( new Error( 'Not a successful response from the backend, got ' + response.statusCode ) );
+						reject( new HttpResponseError( 'Unable to get scan status', response, body ) );
 					}
 
 				} catch( e ){

--- a/src/app/lib/backend-service.spec.js
+++ b/src/app/lib/backend-service.spec.js
@@ -3,6 +3,7 @@ const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
 const faker = require( 'faker' );
 const metadata = require( './metadata' );
+const HttpResponseError = require( './HttpResponseError' );
 
 const modulePath = './backend-service';
 const getFakeData = jasmine.helpers.getFakeData;
@@ -358,7 +359,7 @@ describe( 'Backend Service', () => {
 					} catch( e ){
 
 						expect( backend.post ).toHaveBeenCalledWith( `/documents/${ documentId }/upload-callback`, token );
-						expect( e ).toEqual( new Error( 'Not a successful response from the backend, got 500' ) );
+						expect( e instanceof HttpResponseError ).toEqual( true );
 					}
 				} );
 			} );

--- a/src/app/sub-apps/barriers/controllers/companies.js
+++ b/src/app/sub-apps/barriers/controllers/companies.js
@@ -2,6 +2,7 @@ const backend = require( '../../../lib/backend-service' );
 const datahub = require( '../../../lib/datahub-service' );
 const Form = require( '../../../lib/Form' );
 const urls = require( '../../../lib/urls' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const LIST_TEMPLATE = 'barriers/views/companies/list';
 
@@ -92,7 +93,7 @@ module.exports = {
 
 			try {
 
-				const { response } = await backend.barriers.saveCompanies( req, barrierId, companies );
+				const { response, body } = await backend.barriers.saveCompanies( req, barrierId, companies );
 
 				if( response.isSuccess ){
 
@@ -100,7 +101,7 @@ module.exports = {
 
 				} else {
 
-					next( new Error( `Unable to save companies for barrier, got ${ response.statusCode } response code` ) );
+					next( new HttpResponseError( 'Unable to save companies for barrier', response, body ) );
 				}
 
 			} catch( e ){

--- a/src/app/sub-apps/barriers/controllers/companies.spec.js
+++ b/src/app/sub-apps/barriers/controllers/companies.spec.js
@@ -1,6 +1,7 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
 const faker = require( 'faker' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const modulePath = './companies';
 
@@ -177,7 +178,6 @@ describe( 'Barrier companies controller', () => {
 				it( 'Should call next with an error', async () => {
 
 					const statusCode = 500;
-					const err = new Error( `Unable to save companies for barrier, got ${ statusCode } response code` );
 
 					backend.barriers.saveCompanies.and.callFake( () => Promise.resolve( { response: {
 						isSuccess: false,
@@ -186,7 +186,8 @@ describe( 'Barrier companies controller', () => {
 
 					await controller.list( req, res, next );
 
-					expect( next ).toHaveBeenCalledWith( err );
+					expect( next ).toHaveBeenCalled();
+					expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 					expect( res.render ).not.toHaveBeenCalled();
 				} );
 			} );

--- a/src/app/sub-apps/barriers/controllers/interactions.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.js
@@ -9,6 +9,7 @@ const uploadDocument = require( '../../../lib/upload-document' );
 const detailVieWModel = require( '../view-models/detail' );
 const interactionsViewModel = require( '../view-models/interactions' );
 const documentControllers = require( '../../../lib/document-controllers' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const NOTE_ERROR = 'Add text for the note.';
 const { OVERSIZE_FILE_MESSAGE, INVALID_FILE_TYPE_MESSAGE, FILE_INFECTED_MESSAGE } = documentControllers;
@@ -329,7 +330,7 @@ module.exports = {
 
 				try {
 
-					const { response } = await backend.barriers.notes.delete( req, noteId );
+					const { response, body } = await backend.barriers.notes.delete( req, noteId );
 
 					if( response.isSuccess ){
 
@@ -337,7 +338,7 @@ module.exports = {
 
 					} else {
 
-						next( new Error( `Could not delete note, got ${ response.statusCode } from backend` ) );
+						next( new HttpResponseError( 'Could not delete note', response, body ) );
 					}
 
 				} catch( e ){

--- a/src/app/sub-apps/barriers/controllers/interactions.spec.js
+++ b/src/app/sub-apps/barriers/controllers/interactions.spec.js
@@ -1,6 +1,7 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
 const faker = require( 'faker' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const modulePath = './interactions';
 const { getFakeData, mocks } = jasmine.helpers;
@@ -888,7 +889,8 @@ describe( 'Barrier interactions controller', () => {
 							await controller.notes.delete( req, res, next );
 
 							expect( res.redirect ).not.toHaveBeenCalled();
-							expect( next ).toHaveBeenCalledWith( new Error( `Could not delete note, got ${ statusCode } from backend` ) );
+							expect( next ).toHaveBeenCalled();
+							expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 						} );
 					} );
 				} );

--- a/src/app/sub-apps/barriers/controllers/location.js
+++ b/src/app/sub-apps/barriers/controllers/location.js
@@ -3,6 +3,7 @@ const Form = require( '../../../lib/Form' );
 const urls = require( '../../../lib/urls' );
 const validators = require( '../../../lib/validators' );
 const backend = require( '../../../lib/backend-service' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 module.exports = {
 
@@ -25,7 +26,7 @@ module.exports = {
 
 			try {
 
-				const { response } = await backend.barriers.saveLocation( req, barrier.id, req.session.location );
+				const { response, body } = await backend.barriers.saveLocation( req, barrier.id, req.session.location );
 
 				delete req.session.location;
 
@@ -35,7 +36,7 @@ module.exports = {
 
 				} else {
 
-					return next( new Error( `Unable to update barrier, got ${ response.statusCode } response code` ) );
+					return next( new HttpResponseError( 'Unable to update barrier', response, body ) );
 				}
 
 			} catch( e ){

--- a/src/app/sub-apps/barriers/controllers/location.spec.js
+++ b/src/app/sub-apps/barriers/controllers/location.spec.js
@@ -1,5 +1,6 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const modulePath = './location';
 const SELECT = 'select-value';
@@ -221,9 +222,8 @@ describe( 'Edit barrier location controller', () => {
 
 					await controller.list( req, res, next );
 
-					const err = new Error( `Unable to update barrier, got ${ response.statusCode } response code` );
-
-					expect( next ).toHaveBeenCalledWith( err );
+					expect( next ).toHaveBeenCalled();
+					expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 				} );
 			});
 

--- a/src/app/sub-apps/barriers/controllers/sectors.js
+++ b/src/app/sub-apps/barriers/controllers/sectors.js
@@ -3,6 +3,7 @@ const Form = require( '../../../lib/Form' );
 const urls = require( '../../../lib/urls' );
 const validators = require( '../../../lib/validators' );
 const metadata = require( '../../../lib/metadata' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 function renderSectors( req, res, sectors, allSectors ){
 
@@ -82,7 +83,7 @@ module.exports = {
 				req.barrierSession.sectors.all.delete();
 				req.barrierSession.sectors.list.delete();
 
-				const { response } = await backend.barriers.saveSectors( req, barrierId, sectors, allSectors );
+				const { response, body } = await backend.barriers.saveSectors( req, barrierId, sectors, allSectors );
 
 				if( response.isSuccess ){
 
@@ -90,7 +91,7 @@ module.exports = {
 
 				} else {
 
-					return next( new Error( `Unable to update barrier, got ${ response.statusCode } response code` ) );
+					return next( new HttpResponseError( 'Unable to update barrier', response, body ) );
 				}
 
 			} catch( e ){

--- a/src/app/sub-apps/barriers/controllers/sectors.spec.js
+++ b/src/app/sub-apps/barriers/controllers/sectors.spec.js
@@ -1,5 +1,6 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const modulePath = './sectors';
 
@@ -234,11 +235,10 @@ describe( 'Barrier sectors controller', () => {
 
 							await controller.list( req, res, next );
 
-							const err = new Error( `Unable to update barrier, got ${ response.statusCode } response code` );
-
 							expect( req.barrierSession.sectors.all.delete ).toHaveBeenCalled();
 							expect( req.barrierSession.sectors.list.delete ).toHaveBeenCalled();
-							expect( next ).toHaveBeenCalledWith( err );
+							expect( next ).toHaveBeenCalled();
+							expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 						} );
 					} );
 				} );

--- a/src/app/sub-apps/barriers/controllers/status.spec.js
+++ b/src/app/sub-apps/barriers/controllers/status.spec.js
@@ -1,5 +1,6 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 const metadata = require( '../../../lib/metadata' );
 
 const modulePath = './status';
@@ -379,7 +380,8 @@ describe( 'Barrier status controller', () => {
 
 										await controller.index( req, res, next );
 
-										expect( next ).toHaveBeenCalledWith( new Error( 'No errors in response body, form not saved - got 400 from backend' ) );
+										expect( next ).toHaveBeenCalled();
+										expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 									} );
 								} );
 							} );
@@ -395,7 +397,8 @@ describe( 'Barrier status controller', () => {
 
 									await controller.index( req, res, next );
 
-									expect( next ).toHaveBeenCalledWith( new Error( 'Unable to save form - got 500 from backend' ) );
+									expect( next ).toHaveBeenCalled();
+									expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 								} );
 							} );
 						} );
@@ -488,7 +491,8 @@ describe( 'Barrier status controller', () => {
 
 										await controller.index( req, res, next );
 
-										expect( next ).toHaveBeenCalledWith( new Error( 'No errors in response body, form not saved - got 400 from backend' ) );
+										expect( next ).toHaveBeenCalled();
+										expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 									} );
 								} );
 							} );
@@ -504,7 +508,9 @@ describe( 'Barrier status controller', () => {
 
 									await controller.index( req, res, next );
 
-									expect( next ).toHaveBeenCalledWith( new Error( 'Unable to save form - got 500 from backend' ) );
+									expect( next ).toHaveBeenCalled();
+									expect( next.calls.count() ).toEqual( 1 );
+									expect( next.calls.argsFor( 0  )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 								} );
 							} );
 						} );

--- a/src/app/sub-apps/barriers/controllers/types.js
+++ b/src/app/sub-apps/barriers/controllers/types.js
@@ -4,6 +4,7 @@ const urls = require( '../../../lib/urls' );
 const validators = require( '../../../lib/validators' );
 const metadata = require( '../../../lib/metadata' );
 const sortGovukItems = require( '../../../lib/sort-govuk-items' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 function barrierTypeToRadio( item ){
 
@@ -83,7 +84,7 @@ module.exports = {
 
 			try {
 
-				const { response } = await backend.barriers.saveTypes( req, barrierId, types );
+				const { response, body } = await backend.barriers.saveTypes( req, barrierId, types );
 
 				if( response.isSuccess ){
 
@@ -92,7 +93,7 @@ module.exports = {
 
 				} else {
 
-					return next( new Error( `Unable to update barrier, got ${ response.statusCode } response code` ) );
+					return next( new HttpResponseError( 'Unable to update barrier', response, body ) );
 				}
 
 			} catch( e ){

--- a/src/app/sub-apps/barriers/controllers/types.spec.js
+++ b/src/app/sub-apps/barriers/controllers/types.spec.js
@@ -1,6 +1,7 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
 const faker = require( 'faker' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const modulePath = './types';
 
@@ -217,10 +218,10 @@ describe( 'Barrier types controller', () => {
 
 							await controller.list( req, res, next );
 
-							const err = new Error( `Unable to update barrier, got ${ response.statusCode } response code` );
-
 							expect( req.barrierSession.types.delete ).not.toHaveBeenCalled();
-							expect( next ).toHaveBeenCalledWith( err );
+							expect( next ).toHaveBeenCalled();
+							expect( next.calls.count() ).toEqual( 1 );
+							expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 						} );
 					} );
 				} );

--- a/src/app/sub-apps/barriers/middleware/params/barrier-id.js
+++ b/src/app/sub-apps/barriers/middleware/params/barrier-id.js
@@ -1,5 +1,6 @@
 const backend = require( '../../../../lib/backend-service' );
 const validators = require( '../../../../lib/validators' );
+const HttpResponseError = require( '../../../../lib/HttpResponseError' );
 
 module.exports = async ( req, res, next, barrierId ) => {
 
@@ -27,7 +28,7 @@ module.exports = async ( req, res, next, barrierId ) => {
 
 				} else {
 
-					next( new Error( 'Error response getting barrier' ) );
+					next( new HttpResponseError( 'Unable to get barrier', response, body ) );
 				}
 			}
 

--- a/src/app/sub-apps/barriers/middleware/params/barrier-id.spec.js
+++ b/src/app/sub-apps/barriers/middleware/params/barrier-id.spec.js
@@ -1,5 +1,6 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../../lib/HttpResponseError' );
 const modulePath = './barrier-id';
 
 describe( 'Barrier Id param middleware', () => {
@@ -70,8 +71,9 @@ describe( 'Barrier Id param middleware', () => {
 
 				expect( req.barrier ).not.toBeDefined();
 				expect( res.locals.barrier ).not.toBeDefined();
-				expect( next ).toHaveBeenCalledWith( new Error( 'Error response getting barrier' ) );
+				expect( next ).toHaveBeenCalled();
 				expect( next.calls.count() ).toEqual( 1 );
+				expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 			} );
 
 			describe( 'When the response statusCode is 404', () => {

--- a/src/app/sub-apps/barriers/middleware/params/company-id.js
+++ b/src/app/sub-apps/barriers/middleware/params/company-id.js
@@ -1,4 +1,6 @@
 const datahub =require( '../../../../lib/datahub-service' );
+const HttpResponseError = require( '../../../../lib/HttpResponseError' );
+
 const isValid = /^[a-zA-Z0-9-_]+$/;
 
 module.exports = async ( req, res, next, id ) => {
@@ -18,7 +20,7 @@ module.exports = async ( req, res, next, id ) => {
 
 			} else {
 
-				throw new Error( 'Not a successful response from datahub' );
+				throw new HttpResponseError( 'Unable to get company from Data Hub', response, body );
 			}
 
 		} catch( e ){

--- a/src/app/sub-apps/barriers/middleware/params/company-id.spec.js
+++ b/src/app/sub-apps/barriers/middleware/params/company-id.spec.js
@@ -1,5 +1,7 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../../lib/HttpResponseError' );
+
 const modulePath = './company-id';
 
 describe( 'Company Id param middleware', () => {
@@ -65,7 +67,9 @@ describe( 'Company Id param middleware', () => {
 				expect( datahub.getCompany ).toHaveBeenCalledWith( id );
 				expect( req.company ).not.toBeDefined();
 				expect( res.locals.company ).not.toBeDefined();
-				expect( next ).toHaveBeenCalledWith( new Error( 'Not a successful response from datahub' ) );
+				expect( next ).toHaveBeenCalled();
+				expect( next.calls.count() ).toEqual( 1 );
+				expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 			} );
 		} );
 

--- a/src/app/sub-apps/barriers/middleware/params/note-id.js
+++ b/src/app/sub-apps/barriers/middleware/params/note-id.js
@@ -1,4 +1,5 @@
 const backend = require( '../../../../lib/backend-service' );
+const HttpResponseError = require( '../../../../lib/HttpResponseError' );
 
 module.exports = async ( req, res, next, noteId ) => {
 
@@ -24,7 +25,7 @@ module.exports = async ( req, res, next, noteId ) => {
 
 		} else {
 
-			throw new Error( `Unable to get interactions for barrier, got ${ response.statusCode } from backend` );
+			throw new HttpResponseError( 'Unable to get interactions for barrier', response, body );
 		}
 	} catch( e ){ next( e ); }
 };

--- a/src/app/sub-apps/barriers/middleware/params/note-id.spec.js
+++ b/src/app/sub-apps/barriers/middleware/params/note-id.spec.js
@@ -1,5 +1,7 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../../lib/HttpResponseError' );
+
 const modulePath = './note-id';
 
 describe( 'Note Id param middleware', () => {
@@ -44,62 +46,63 @@ describe( 'Note Id param middleware', () => {
 			describe( 'When the response is a success', () => {
 				describe( 'When the note id matches', () => {
 					it( 'Should add the note to the req', async () => {
-	
+
 						const notes = [ { id: 456 }, { id } ];
 						const promise = Promise.resolve( { response: { isSuccess: true }, body: { results: notes } } );
-	
+
 						backend.barriers.getInteractions.and.callFake( () => promise );
-	
+
 						await middleware( req, res, next, id );
-	
+
 						expect( backend.barriers.getInteractions ).toHaveBeenCalledWith( req, barrierId );
 						expect( req.note ).toEqual( notes[ 1 ] );
 						expect( next ).toHaveBeenCalledWith();
 					} );
 				} );
-	
+
 				describe( 'When the note id does NOT match', () => {
 					it( 'Should call next with an error', async () => {
-	
+
 						const notes = [ { id: 456 } ];
 						const promise = Promise.resolve( { response: { isSuccess: true }, body: { results: notes } } );
-	
+
 						backend.barriers.getInteractions.and.callFake( () => promise );
-	
+
 						await middleware( req, res, next, id );
-	
+
 						expect( backend.barriers.getInteractions ).toHaveBeenCalledWith( req, barrierId );
 						expect( req.note ).not.toBeDefined();
 						expect( next ).toHaveBeenCalledWith( new Error( `Unable to match note id ${ id } for barrier ${ barrierId }` ) );
 					} );
 				} );
 			} );
-	
+
 			describe( 'When the response is NOT a success', () => {
 				it( 'Should call next with an error', async () => {
-	
+
 					const promise = Promise.resolve( { response: { isSuccess: false, statusCode: 500 }, body: {} } );
-	
+
 					backend.barriers.getInteractions.and.callFake( () => promise );
-	
+
 					await middleware( req, res, next, id );
-	
+
 					expect( backend.barriers.getInteractions ).toHaveBeenCalledWith( req, barrierId );
 					expect( req.note ).not.toBeDefined();
-					expect( next ).toHaveBeenCalledWith( new Error( 'Unable to get interactions for barrier, got 500 from backend' ) );
+					expect( next ).toHaveBeenCalled();
+					expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 				} );
 			} );
-	
+
 			describe( 'When the call errors', () => {
 				it( 'Should call next with the error', async () => {
-	
+
 					const err = new Error( 'a datahub error' );
 					const promise = Promise.reject( err );
-	
+
 					backend.barriers.getInteractions.and.callFake( () => promise );
-	
+
 					await middleware( req, res, next, id );
-	
+
 					expect( backend.barriers.getInteractions ).toHaveBeenCalledWith( req, barrierId );
 					expect( next ).toHaveBeenCalledWith( err );
 				} );

--- a/src/app/sub-apps/reports/controllers/admin-areas.js
+++ b/src/app/sub-apps/reports/controllers/admin-areas.js
@@ -3,6 +3,7 @@ const metadata = require( '../../../lib/metadata' );
 const Form = require( '../../../lib/Form' );
 const urls = require( '../../../lib/urls' );
 const validators = require( '../../../lib/validators' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 module.exports = {
 
@@ -60,7 +61,7 @@ module.exports = {
 
 				} else {
 
-					return next( new Error( `Unable to ${ isUpdate ? 'update' : 'save' } report, got ${ response.statusCode } response code` ) );
+					return next( new HttpResponseError( `Unable to ${ isUpdate ? 'update' : 'save' } report`, response, body ) );
 				}
 
 			} catch( e ){

--- a/src/app/sub-apps/reports/controllers/admin-areas.spec.js
+++ b/src/app/sub-apps/reports/controllers/admin-areas.spec.js
@@ -1,5 +1,6 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const modulePath = './admin-areas';
 
@@ -198,8 +199,12 @@ describe( 'Report controllers', () => {
 
 								await controller.list( req, res, next );
 
+								const err = next.calls.argsFor( 0 )[ 0 ];
+
 								expect( res.redirect ).not.toHaveBeenCalled();
-								expect( next ).toHaveBeenCalledWith( new Error( 'Unable to update report, got 404 response code' ) );
+								expect( next ).toHaveBeenCalled();
+								expect( err.message.startsWith( 'Unable to update report' ) ).toEqual( true );
+								expect( err instanceof HttpResponseError ).toEqual( true );
 							} );
 						} );
 					} );
@@ -284,7 +289,11 @@ describe( 'Report controllers', () => {
 
 							await controller.list( req, res, next );
 
-							expect( next ).toHaveBeenCalledWith( new Error( 'Unable to save report, got 123 response code' ) );
+							const err = next.calls.argsFor( 0 )[ 0 ];
+
+							expect( next ).toHaveBeenCalled();
+							expect( err instanceof HttpResponseError ).toEqual( true );
+							expect( err.message.startsWith( 'Unable to save report' ) ).toEqual( true );
 						} );
 					} );
 				});

--- a/src/app/sub-apps/reports/controllers/country.js
+++ b/src/app/sub-apps/reports/controllers/country.js
@@ -4,6 +4,7 @@ const urls = require( '../../../lib/urls' );
 const validators = require( '../../../lib/validators' );
 const backend = require( '../../../lib/backend-service' );
 const getDateParts = require( '../../../lib/get-date-parts' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const { PART_RESOLVED } = metadata.barrier.status.types;
 
@@ -104,7 +105,7 @@ module.exports = async ( req, res, next ) => {
 
 					} else {
 
-						return next( new Error( `Unable to ${ isUpdate ? 'update' : 'save' } report, got ${ response.statusCode } response code` ) );
+						return next( new HttpResponseError( `Unable to ${ isUpdate ? 'update' : 'save' } report`, response, body ) );
 					}
 
 				} catch( e ){

--- a/src/app/sub-apps/reports/controllers/country.spec.js
+++ b/src/app/sub-apps/reports/controllers/country.spec.js
@@ -1,4 +1,5 @@
 const proxyquire = require( 'proxyquire' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const { RESOLVED, PART_RESOLVED } = require( '../../../lib/metadata' ).barrier.status.types;
 const modulePath = './country';
@@ -221,8 +222,11 @@ describe( 'Report controllers', () => {
 
 										await controller( req, res, next );
 
+										const err = next.calls.argsFor( 0 )[ 0 ];
 										expect( res.redirect ).not.toHaveBeenCalled();
-										expect( next ).toHaveBeenCalledWith( new Error( 'Unable to update report, got 404 response code' ) );
+										expect( next ).toHaveBeenCalled();
+										expect( err instanceof HttpResponseError ).toEqual( true );
+										expect( err.message.startsWith( 'Unable to update report' ) ).toEqual( true );
 									} );
 								} );
 							} );
@@ -356,7 +360,11 @@ describe( 'Report controllers', () => {
 
 								await controller( req, res, next );
 
-								expect( next ).toHaveBeenCalledWith( new Error( 'Unable to save report, got 123 response code' ) );
+								const err = next.calls.argsFor( 0 )[ 0 ];
+
+								expect( next ).toHaveBeenCalled();
+								expect( err instanceof HttpResponseError ).toEqual( true );
+								expect( err.message.startsWith( 'Unable to save report' ) ).toEqual( true );
 							} );
 						} );
 					});

--- a/src/app/sub-apps/reports/controllers/has-admin-areas.js
+++ b/src/app/sub-apps/reports/controllers/has-admin-areas.js
@@ -4,6 +4,7 @@ const Form = require( '../../../lib/Form' );
 const urls = require( '../../../lib/urls' );
 const validators = require( '../../../lib/validators' );
 const govukItemsFromObj = require( '../../../lib/govuk-items-from-object' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 module.exports = async ( req, res, next ) => {
 
@@ -71,7 +72,7 @@ module.exports = async ( req, res, next ) => {
 
 					} else {
 
-						return next( new Error( `Unable to ${ isUpdate ? 'update' : 'save' } report, got ${ response.statusCode } response code` ) );
+						return next( new HttpResponseError( `Unable to ${ isUpdate ? 'update' : 'save' } report`, response, body ) );
 					}
 
 				} catch( e ){

--- a/src/app/sub-apps/reports/controllers/has-admin-areas.spec.js
+++ b/src/app/sub-apps/reports/controllers/has-admin-areas.spec.js
@@ -1,5 +1,6 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const modulePath = './has-admin-areas';
 
@@ -243,8 +244,11 @@ describe( 'Report controllers', () => {
 
 									await controller( req, res, next );
 
+									const err = next.calls.argsFor( 0 )[ 0 ];
 									expect( res.redirect ).not.toHaveBeenCalled();
-									expect( next ).toHaveBeenCalledWith( new Error( 'Unable to update report, got 404 response code' ) );
+									expect( next ).toHaveBeenCalled();
+									expect( err instanceof HttpResponseError ).toEqual( true );
+									expect( err.message.startsWith( 'Unable to update report' ) ).toEqual( true );
 								} );
 							} );
 						} );
@@ -314,7 +318,11 @@ describe( 'Report controllers', () => {
 
 								await controller( req, res, next );
 
-								expect( next ).toHaveBeenCalledWith( new Error( 'Unable to save report, got 123 response code' ) );
+								const err = next.calls.argsFor( 0 )[ 0 ];
+
+								expect( next ).toHaveBeenCalled();
+								expect( err instanceof HttpResponseError ).toEqual( true );
+								expect( err.message.startsWith( 'Unable to save report' ) ).toEqual( true );
 							} );
 						} );
 					});

--- a/src/app/sub-apps/reports/controllers/index.js
+++ b/src/app/sub-apps/reports/controllers/index.js
@@ -1,6 +1,7 @@
 const metadata = require( '../../../lib/metadata' );
 const backend = require( '../../../lib/backend-service' );
 const urls = require( '../../../lib/urls' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 const reportDetailViewModel = require( '../view-models/detail' );
 const reportsViewModel = require( '../view-models/reports' );
 
@@ -20,7 +21,7 @@ async function renderDashboard( req, res, next, isDelete = false, currentReportI
 
 		} else {
 
-			throw new Error( `Got ${ response.statusCode } response from backend` );
+			throw new HttpResponseError( 'Unable to get reports', response, body );
 		}
 
 	} catch( e ){
@@ -52,12 +53,12 @@ module.exports = {
 
 			if( req.report.created_by.id !== req.user.id ){
 
-				return next( new Error( 'Cannot delete a note that is not created by the current user' ) );
+				return next( new Error( 'Cannot delete a report that is not created by the current user' ) );
 			}
 
 			try {
 
-				const { response } = await backend.reports.delete( req, currentReportId );
+				const { response, body } = await backend.reports.delete( req, currentReportId );
 
 				if( response.isSuccess ){
 
@@ -65,7 +66,7 @@ module.exports = {
 
 				} else {
 
-					throw new Error( `Got ${ response.statusCode } response from backend` );
+					throw new HttpResponseError( 'Unable to delete report', response, body );
 				}
 
 			} catch( e ){

--- a/src/app/sub-apps/reports/controllers/index.spec.js
+++ b/src/app/sub-apps/reports/controllers/index.spec.js
@@ -1,5 +1,6 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const modulePath = './index';
 
@@ -181,8 +182,9 @@ describe( 'Report controllers', () => {
 
 					await controller.index( req, res, next );
 
-					expect( next ).toHaveBeenCalledWith( new Error( `Got ${ unfinishedReportsResponse.response.statusCode } response from backend` ) );
 					expect( backend.reports.getAll ).toHaveBeenCalledWith( req );
+					expect( next ).toHaveBeenCalled();
+					expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 					expect( res.render ).not.toHaveBeenCalled();
 				} );
 			} );
@@ -311,8 +313,9 @@ describe( 'Report controllers', () => {
 
 						await controller.delete( req, res, next );
 
-						expect( next ).toHaveBeenCalledWith( new Error( `Got ${ unfinishedReportsResponse.response.statusCode } response from backend` ) );
 						expect( backend.reports.getAll ).toHaveBeenCalledWith( req );
+						expect( next ).toHaveBeenCalled();
+						expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 						expect( res.render ).not.toHaveBeenCalled();
 					} );
 				} );
@@ -348,7 +351,7 @@ describe( 'Report controllers', () => {
 
 					expect( backend.reports.delete ).not.toHaveBeenCalled();
 					expect( res.render ).not.toHaveBeenCalled();
-					expect( next ).toHaveBeenCalledWith( new Error( 'Cannot delete a note that is not created by the current user' ) );
+					expect( next ).toHaveBeenCalledWith( new Error( 'Cannot delete a report that is not created by the current user' ) );
 				} );
 			} );
 
@@ -377,13 +380,13 @@ describe( 'Report controllers', () => {
 					it( 'Should call next with an error', async () => {
 
 						const statusCode = 500;
-						const err = new Error( `Got ${ statusCode } response from backend` );
 
 						backend.reports.delete.and.callFake( () => Promise.resolve( { response: { isSuccess: false, statusCode } } ) );
 
 						await controller.delete( req, res, next );
 
-						expect( next ).toHaveBeenCalledWith( err );
+						expect( next ).toHaveBeenCalled();
+						expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 						expect( res.render ).not.toHaveBeenCalled();
 					} );
 				} );

--- a/src/app/sub-apps/reports/controllers/sectors.js
+++ b/src/app/sub-apps/reports/controllers/sectors.js
@@ -3,6 +3,7 @@ const metadata = require( '../../../lib/metadata' );
 const Form = require( '../../../lib/Form' );
 const urls = require( '../../../lib/urls' );
 const validators = require( '../../../lib/validators' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 module.exports = {
 
@@ -29,7 +30,7 @@ module.exports = {
 					delete req.session.sectors;
 					delete req.session.allSectors;
 
-					const { response } = await backend.reports.saveSectors( req, reportId, { sectors, allSectors } );
+					const { response, body } = await backend.reports.saveSectors( req, reportId, { sectors, allSectors } );
 
 					if( response.isSuccess ){
 
@@ -38,7 +39,7 @@ module.exports = {
 
 					} else {
 
-						return next( new Error( `Unable to update report, got ${ response.statusCode } response code` ) );
+						return next( new HttpResponseError( 'Unable to update report', response, body ) );
 					}
 
 				} catch( e ){

--- a/src/app/sub-apps/reports/controllers/sectors.spec.js
+++ b/src/app/sub-apps/reports/controllers/sectors.spec.js
@@ -1,5 +1,6 @@
 const proxyquire = require( 'proxyquire' );
 const uuid = require( 'uuid/v4' );
+const HttpResponseError = require( '../../../lib/HttpResponseError' );
 
 const modulePath = './sectors';
 
@@ -236,13 +237,13 @@ describe( 'Report controllers', () => {
 							it( 'Should call next with an error', async () => {
 
 								const statusCode = 500;
-								const err = new Error( `Unable to update report, got ${ statusCode } response code` );
 
 								backend.reports.saveSectors.and.callFake( () => Promise.resolve( { response: { isSuccess: false, statusCode } } ) );
 
 								await controller.list( req, res, next );
 
-								expect( next ).toHaveBeenCalledWith( err );
+								expect( next ).toHaveBeenCalled();
+								expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 								expect( res.render ).not.toHaveBeenCalled();
 								expect( req.session.sectors ).not.toBeDefined();
 							} );

--- a/src/app/sub-apps/reports/middleware/params/report-id.js
+++ b/src/app/sub-apps/reports/middleware/params/report-id.js
@@ -1,5 +1,7 @@
 const backend = require( '../../../../lib/backend-service' );
 const { isUuid } = require( '../../../../lib/validators' );
+const HttpResponseError = require( '../../../../lib/HttpResponseError' );
+
 const maxUuidLength = 60;
 
 module.exports = async ( req, res, next, reportId ) => {
@@ -30,7 +32,7 @@ module.exports = async ( req, res, next, reportId ) => {
 
 				} else {
 
-					next( new Error( 'Error response getting report' ) );
+					next( new HttpResponseError( 'Unable to get report', response, body ) );
 				}
 
 			} catch( e ){

--- a/src/app/sub-apps/reports/middleware/params/report-id.spec.js
+++ b/src/app/sub-apps/reports/middleware/params/report-id.spec.js
@@ -1,4 +1,6 @@
 const proxyquire = require( 'proxyquire' );
+const HttpResponseError = require( '../../../../lib/HttpResponseError' );
+
 const modulePath = './report-id';
 
 describe( 'Report Id param middleware', () => {
@@ -62,7 +64,8 @@ describe( 'Report Id param middleware', () => {
 						expect( req.session.report ).not.toBeDefined();
 						expect( req.report ).not.toBeDefined();
 						expect( res.locals.report ).not.toBeDefined();
-						expect( next ).toHaveBeenCalledWith( new Error( 'Error response getting report' ) );
+						expect( next ).toHaveBeenCalled();
+						expect( next.calls.argsFor( 0 )[ 0 ] instanceof HttpResponseError ).toEqual( true );
 					} );
 				} );
 

--- a/src/app/views/error/default.njk
+++ b/src/app/views/error/default.njk
@@ -12,10 +12,10 @@
 		<h2 class="govuk-heading-s">Code: {{ error.code }}</h2>
 		{% endif %}
 
-		{% if error.responseBody %}
+		{% if error.response.body %}
 			<h2 class="govuk-heading-s">Response Body</h2>
 			<p class="stack-trace">
-				{{ error.responseBody | dump( 2 ) }}
+				{{ error.response.body | dump( 2 ) }}
 			</p>
 		{% endif %}
 


### PR DESCRIPTION
Use `HttpResponseError` in all places where it makes sense to keep all code consistent and display better errors with more data in Sentry