### PR TITLE
Handle a 404 for reports

### DIFF
--- a/src/app/app.spec.js
+++ b/src/app/app.spec.js
@@ -1828,6 +1828,44 @@ describe( 'App', function(){
 							} );
 						} );
 					} );
+
+					describe( 'Missing report', () => {
+
+						beforeEach( () => {
+
+							intercept.backend()
+								.get( `/reports/${ reportId }` )
+								.reply( 404, '' );
+						} );
+
+						describe( 'Report detail', () => {
+							describe( 'When it is not a barrier', () => {
+								it( 'Should render an error page', ( done ) => {
+
+									intercept.backend()
+										.get( `/barriers/${ reportId }` )
+										.reply( 404, '' );
+
+									app
+										.get( urls.reports.detail( reportId ) )
+										.end( checkPage( 'Market Access - Barrier not found', done, 404 ) );
+								} );
+							} );
+
+							describe( 'When it is a barrier', () => {
+								it( 'Should redirect to the barrier detail page', ( done ) => {
+
+									intercept.backend()
+										.get( `/barriers/${ reportId }` )
+										.reply( 200, intercept.stub( '/backend/barriers/barrier' ) );
+
+									app
+										.get( urls.reports.detail( reportId ) )
+										.end( checkRedirect( urls.barriers.detail( reportId ), done ) );
+								} );
+							} );
+						} );
+					} );
 				} );
 			} );
 		} );

--- a/src/app/middleware/errors.js
+++ b/src/app/middleware/errors.js
@@ -40,6 +40,12 @@ module.exports = {
 					res.render( 'error/unable-to-download' );
 					break;
 
+				case 'REPORT_NOT_FOUND':
+
+					res.status( 404 );
+					res.render( 'error/report-not-found' );
+					break;
+
 				default:
 
 					res.status( 500 );

--- a/src/app/middleware/errors.spec.js
+++ b/src/app/middleware/errors.spec.js
@@ -72,10 +72,10 @@ describe( 'errors middleware', function(){
 				describe( 'A TOO_MANY_BYTES error', function(){
 					it( 'Should return a 413 status', function(){
 
-						const tooManyBytesError = new Error( 'Too many bytes' );
-						tooManyBytesError.code = 'TOO_MANY_BYTES';
+						const err = new Error( 'Too many bytes' );
+						err.code = 'TOO_MANY_BYTES';
 
-						middleware.catchAll( tooManyBytesError, req, res, next );
+						middleware.catchAll( err, req, res, next );
 
 						expect( res.sendStatus ).toHaveBeenCalledWith( 413 );
 						expect( reporter.captureException ).not.toHaveBeenCalled();
@@ -85,10 +85,10 @@ describe( 'errors middleware', function(){
 				describe( 'A EBADCSRFTOKEN error', function(){
 					it( 'Should return a 400 status', function(){
 
-						const invalidCsrfTokenError = new Error( 'Invalid csrf token' );
-						invalidCsrfTokenError.code = 'EBADCSRFTOKEN';
+						const err = new Error( 'Invalid csrf token' );
+						err.code = 'EBADCSRFTOKEN';
 
-						middleware.catchAll( invalidCsrfTokenError, req, res, next );
+						middleware.catchAll( err, req, res, next );
 
 						expect( res.status ).toHaveBeenCalledWith( 400 );
 						expect( res.render ).toHaveBeenCalledWith( 'error/invalid-csrf-token' );
@@ -99,13 +99,27 @@ describe( 'errors middleware', function(){
 				describe( 'A DOWNLOAD_FAIL error', function(){
 					it( 'Should return a 400 status', function(){
 
-						const invalidCsrfTokenError = new Error( 'Download error' );
-						invalidCsrfTokenError.code = 'DOWNLOAD_FAIL';
+						const err = new Error( 'Download error' );
+						err.code = 'DOWNLOAD_FAIL';
 
-						middleware.catchAll( invalidCsrfTokenError, req, res, next );
+						middleware.catchAll( err, req, res, next );
 
 						expect( res.status ).toHaveBeenCalledWith( 500 );
 						expect( res.render ).toHaveBeenCalledWith( 'error/unable-to-download' );
+						expect( reporter.captureException ).not.toHaveBeenCalled();
+					} );
+				} );
+
+				describe( 'A REPORT_NOT_FOUND error', function(){
+					it( 'Should return a 404 status', function(){
+
+						const err = new Error( 'Download error' );
+						err.code = 'REPORT_NOT_FOUND';
+
+						middleware.catchAll( err, req, res, next );
+
+						expect( res.status ).toHaveBeenCalledWith( 404 );
+						expect( res.render ).toHaveBeenCalledWith( 'error/report-not-found' );
 						expect( reporter.captureException ).not.toHaveBeenCalled();
 					} );
 				} );

--- a/src/app/views/error/report-not-found.njk
+++ b/src/app/views/error/report-not-found.njk
@@ -1,0 +1,11 @@
+{% extends 'layout.njk' %}
+
+{% block page_title %}{{ super() }} - Barrier not found{% endblock %}
+
+{% block page_content %}
+	<h1 class="error-heading">Barrier not found</h1>
+
+	<p>
+		We could not find the barrier, try searching for it on the <a href="{{ urls.findABarrier() }}">find a barrier page</a>.
+	</p>
+{% endblock %}


### PR DESCRIPTION
If a 404 is returned for a report then check if it is now a barrier
- If it is then redirect to the barrier detail
- If not then render a 404 page
