### PR TITLE
Handle redis down

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -20,6 +20,7 @@ const errors = require( './middleware/errors' );
 const sessionStore = require( './middleware/session-store' );
 const auth = require( './middleware/auth' );
 const ssoBypass = require( './middleware/sso-bypass' );
+const redisCheck = require( './middleware/redis-check' );
 
 module.exports = {
 
@@ -67,6 +68,8 @@ module.exports = {
 		app.use( morganLogger( ( isDev ? 'dev' : 'combined' ) ) );
 		app.use( headers( isDev ) );
 		app.use( ping );
+
+		app.use( redisCheck );
 
 		app.use( sessionStore.create() );
 		if( isDev ){ app.use( ssoBypass ); }

--- a/src/app/lib/redis-client.js
+++ b/src/app/lib/redis-client.js
@@ -2,6 +2,7 @@ const redis = require( 'redis' );
 
 const config = require( '../config' );
 const logger = require( './logger' );
+const reporter = require( './reporter' );
 
 const options = {};
 
@@ -31,7 +32,7 @@ module.exports = {
 			client.on( 'error', ( e ) => {
 				logger.error( 'Error connecting to redis' );
 				logger.error( e );
-				throw e;
+				reporter.captureException( e );
 			} );
 
 			client.on( 'connect', () => {

--- a/src/app/lib/static-globals.js
+++ b/src/app/lib/static-globals.js
@@ -13,4 +13,5 @@ module.exports = function( env ){
 	env.addGlobal( 'feedbackEmail', config.feedbackEmail );
 	env.addGlobal( 'maxFileSize', fileSize( config.files.maxSize ) );
 	env.addGlobal( 'env', config.environment );
+	env.addGlobal( 'assetPath', '/govuk-public' );
 };

--- a/src/app/lib/static-globals.spec.js
+++ b/src/app/lib/static-globals.spec.js
@@ -127,4 +127,12 @@ describe( 'Static globals', function(){
 		expect( args[ 0 ] ).toEqual( 'env' );
 		expect( args[ 1 ] ).toEqual( environment );
 	} );
+
+	it( 'Should set the assetPath', () => {
+
+		const args = calls.argsFor( 9 );
+
+		expect( args[ 0 ] ).toEqual( 'assetPath' );
+		expect( args[ 1 ] ).toEqual( '/govuk-public' );
+	} );
 } );

--- a/src/app/middleware/redis-check.js
+++ b/src/app/middleware/redis-check.js
@@ -1,0 +1,21 @@
+const redisClient = require( '../lib/redis-client' );
+
+const client = redisClient.get();
+let connected = false;
+
+client.on( 'error', () => {
+	connected = false;
+} );
+
+
+client.on( 'ready', () => {
+	connected = true;
+} );
+
+module.exports = ( req, res, next ) => {
+	if( connected ){
+		next();
+	} else {
+		res.render( 'error/redis-lost' );
+	}
+};

--- a/src/app/middleware/redis-check.spec.js
+++ b/src/app/middleware/redis-check.spec.js
@@ -1,0 +1,75 @@
+const proxyquire = require( 'proxyquire' );
+const modulePath = './redis-check';
+const TEMPLATE = 'error/redis-lost';
+
+describe( 'redis-check middleware', () => {
+
+	let req;
+	let res;
+	let next;
+	let middleware;
+	let redisClient;
+
+	function getEventHandler( event ){
+
+		const l = redisClient.on.calls.count();
+		let i = 0;
+		let args;
+
+		for( ; i < l; i++ ){
+
+			args = redisClient.on.calls.argsFor( i );
+
+			if( args[ 0 ] === event ){
+
+				return args[ 1 ];
+			}
+		}
+	}
+
+	beforeEach( () => {
+
+		({ req, res, next } = jasmine.helpers.mocks.middleware());
+		redisClient = {
+			on: jasmine.createSpy( 'redis.client.on' )
+		};
+
+		middleware = proxyquire( modulePath, {
+			'../lib/redis-client': {
+				get: () => redisClient,
+			},
+		} );
+	} );
+
+	describe( 'The default state', () => {
+		it( 'Renders the redis lost error', () => {
+			middleware( req, res, next );
+
+			expect( res.render ).toHaveBeenCalledWith( TEMPLATE );
+		} );
+	} );
+
+	describe( 'When the redis client fires a ready event', () => {
+		it( 'Calls next', () => {
+
+			getEventHandler( 'ready' )();
+
+			middleware( req, res, next );
+
+			expect( next ).toHaveBeenCalledWith();
+			expect( res.render ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'When the redis client fires an error event', () => {
+		it( 'Calls next', () => {
+
+			getEventHandler( 'error' )();
+
+			middleware( req, res, next );
+
+			expect( next ).not.toHaveBeenCalled();
+			expect( res.render ).toHaveBeenCalledWith( TEMPLATE );
+		} );
+	} );
+} );

--- a/src/app/views/error/redis-lost.njk
+++ b/src/app/views/error/redis-lost.njk
@@ -1,0 +1,11 @@
+{% extends 'layout.njk' %}
+
+{% block content %}
+
+	<h1 class="error-heading">Unexpected error</h1>
+
+	<p>
+		Part of the system is down, please try again shortly. The team has been notified.
+	</p>
+
+{% endblock %}

--- a/src/app/views/layout.njk
+++ b/src/app/views/layout.njk
@@ -1,8 +1,6 @@
 {% from 'datahub-header/component/header.njk' import datahubHeader %}
 {% from 'app-components/govuk-footer-ma.njk' import govukFooterMa %}
 
-{% set assetPath = '/govuk-public' %}
-
 {% extends 'marketaccess-template.njk' %}{# extend from govuk-template #}
 
 {% block pageTitle %}{% block page_title %}Market Access{% endblock %}{% endblock %}


### PR DESCRIPTION
**Implementation notes**

When the app loses the connection to Redis it would crash, this stops that from happening and instead renders an error page.

**Checklist**

- [x] Has the branch been rebased to develop?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
