### PR TITLE
Remove uuid from Sentry error message

### DIFF
--- a/src/app/controllers/sso.js
+++ b/src/app/controllers/sso.js
@@ -34,7 +34,7 @@ function checkCallbackErrors( errorParam, stateParam, codeParam, stateId ){
 
 	if( stateParam !== stateId ){
 
-		return `StateId mismatch: '${ stateParam }' !== '${ stateId }'`;
+		return 'SSO stateId mismatch';
 	}
 
 	if( codeParam.length > config.sso.paramLength ){

--- a/src/app/controllers/sso.spec.js
+++ b/src/app/controllers/sso.spec.js
@@ -306,7 +306,7 @@ describe( 'SSO controller', () => {
 					createController();
 					controller.callback( req, res, next );
 
-					expect( next ).toHaveBeenCalledWith( new Error( `StateId mismatch: '${ stateParam }' !== '${ uuid }'` ) );
+					expect( next ).toHaveBeenCalledWith( new Error( 'SSO stateId mismatch' ) );
 					expect( request ).not.toHaveBeenCalled();
 				} );
 			} );


### PR DESCRIPTION
**Implementation notes**

To make it clear in Sentry these are all the same error, this stops each one being unique
It's also unneccesary to report the UUIDs and was mainly for testing

**Checklist**

- [ ] Has the branch been rebased to develop?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or Acceptance)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
